### PR TITLE
Silence false positive clang-tidy warning

### DIFF
--- a/include/rapidjson/internal/stack.h
+++ b/include/rapidjson/internal/stack.h
@@ -17,6 +17,7 @@
 
 #include "../allocators.h"
 #include "swap.h"
+#include <cstddef>
 
 #if defined(__clang__)
 RAPIDJSON_DIAG_PUSH
@@ -114,7 +115,7 @@ public:
     template<typename T>
     RAPIDJSON_FORCEINLINE void Reserve(size_t count = 1) {
          // Expand the stack if needed
-        if (RAPIDJSON_UNLIKELY(stackTop_ + sizeof(T) * count > stackEnd_))
+        if (RAPIDJSON_UNLIKELY(static_cast<std::ptrdiff_t>(sizeof(T) * count) > (stackEnd_ - stackTop_)))
             Expand<T>(count);
     }
 
@@ -127,7 +128,7 @@ public:
     template<typename T>
     RAPIDJSON_FORCEINLINE T* PushUnsafe(size_t count = 1) {
         RAPIDJSON_ASSERT(stackTop_);
-        RAPIDJSON_ASSERT(stackTop_ + sizeof(T) * count <= stackEnd_);
+        RAPIDJSON_ASSERT(static_cast<std::ptrdiff_t>(sizeof(T) * count) <= (stackEnd_ - stackTop_));
         T* ret = reinterpret_cast<T*>(stackTop_);
         stackTop_ += sizeof(T) * count;
         return ret;


### PR DESCRIPTION
The existing check can't be understood by clang-analyze/clang-tidy and reports a null pointer dereference down the line and produces these warnings:

```
include/rapidjson/internal/itoa.h:52:19: warning: Dereference of null pointer [clang-analyzer-core.NullDereference]
        *buffer++ = cDigitsLut[d2 + 1];
                  ^
tidy.cpp:7:5: note: Calling 'Writer::Int'
    writer.Int(1);
    ^
include/rapidjson/writer.h:174:72: note: Calling 'Writer::WriteInt'
    bool Int(int i)             { Prefix(kNumberType); return EndValue(WriteInt(i)); }
                                                                       ^
include/rapidjson/writer.h:480:23: note: Calling 'i32toa'
    const char* end = internal::i32toa(i, buffer);
                      ^
include/rapidjson/internal/itoa.h:115:5: note: Taking false branch
    if (value < 0) {
    ^
include/rapidjson/internal/itoa.h:120:12: note: Calling 'u32toa'
    return u32toa(u, buffer);
           ^
include/rapidjson/internal/itoa.h:42:5: note: Taking true branch
    if (value < 10000) {
    ^
include/rapidjson/internal/itoa.h:46:9: note: Taking false branch
        if (value >= 1000)
        ^
include/rapidjson/internal/itoa.h:48:9: note: Taking false branch
        if (value >= 100)
        ^
include/rapidjson/internal/itoa.h:50:9: note: Taking false branch
        if (value >= 10)
        ^
include/rapidjson/internal/itoa.h:52:19: note: Dereference of null pointer
        *buffer++ = cDigitsLut[d2 + 1];
                  ^
```

(similar for other types of writers)

The sample program I used is

``` cpp
#include <rapidjson/writer.h>

int main(int, char*[]) {
    using namespace rapidjson;
    StringBuffer sb;
    Writer<StringBuffer> writer(sb);
    writer.Int(1);
    return 0;
}
```

It seems that clang-tidy is not sure that an allocation ever happens.
