### PR TITLE
Fix for issue #849, standardise error message.

### DIFF
--- a/include/rapidjson/internal/strtod.h
+++ b/include/rapidjson/internal/strtod.h
@@ -24,12 +24,28 @@ RAPIDJSON_NAMESPACE_BEGIN
 namespace internal {
 
 inline double FastPath(double significand, int exp) {
-    if (exp < -308)
-        return 0.0;
-    else if (exp >= 0)
-        return significand * internal::Pow10(exp);
-    else
-        return significand / internal::Pow10(-exp);
+	if (exp < -308)
+		return 0.0;
+	else if (exp >= 0)
+	{
+		if (std::isinf(significand * internal::Pow10(exp))) {
+			std::cout << "Number too big to be stored in double. ";
+			return INFINITY;
+		}
+		else {
+			return significand * internal::Pow10(exp);
+		}
+	}
+	else {
+		if (std::isinf(significand / internal::Pow10(-exp))) {
+			std::cout << "Number too big to be stored in double. ";
+			return -INFINITY;
+		}
+		else {
+			return significand / internal::Pow10(-exp);
+		}
+		
+	}
 }
 
 inline double StrtodNormalPrecision(double d, int p) {


### PR DESCRIPTION
For issue #849 - Added following code to strtod.h to make error message more consistent. 

`inline double FastPath(double significand, int exp) {
	if (exp < -308)
		return 0.0;
	else if (exp >= 0)
	{
		if (std::isinf(significand * internal::Pow10(exp))) {
			std::cout << "Number too big to be stored in double. ";
			return INFINITY;
		}
		else {
			return significand * internal::Pow10(exp);
		}
	}
	else {
		if (std::isinf(significand / internal::Pow10(-exp))) {
			std::cout << "Number too big to be stored in double. ";
			return -INFINITY;
		}
		else {
			return significand / internal::Pow10(-exp);
		}
		
	}
}`