### PR TITLE
Added INTERFACE target RapidJSON

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,9 @@ SET(CMAKE_INSTALL_DIR "${_CMAKE_INSTALL_DIR}" CACHE PATH "The directory cmake fi
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+add_library(RapidJSON INTERFACE)
+target_include_directories(RapidJSON INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
 if(RAPIDJSON_BUILD_DOC)
     add_subdirectory(doc)
 endif()


### PR DESCRIPTION
The patch gives ability to use RapidJSON as subproject maner:
```
add_subdirectory(deps/rapidjson)
...
add_executable(app main.cpp)
target_link_libraries(app RapidJSON)
```
No need additional include_directories or any other command in CMakeLists.txt