### PR TITLE
Use schema allocator for regex

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -935,7 +935,7 @@ private:
     };
 
 #if RAPIDJSON_SCHEMA_USE_INTERNALREGEX
-        typedef internal::GenericRegex<EncodingType> RegexType;
+        typedef internal::GenericRegex<EncodingType, AllocatorType> RegexType;
 #elif RAPIDJSON_SCHEMA_USE_STDREGEX
         typedef std::basic_regex<Ch> RegexType;
 #else
@@ -995,7 +995,7 @@ private:
     template <typename ValueType>
     RegexType* CreatePattern(const ValueType& value) {
         if (value.IsString()) {
-            RegexType* r = new (allocator_->Malloc(sizeof(RegexType))) RegexType(value.GetString());
+            RegexType* r = new (allocator_->Malloc(sizeof(RegexType))) RegexType(value.GetString(), allocator_);
             if (!r->IsValid()) {
                 r->~RegexType();
                 AllocatorType::Free(r);


### PR DESCRIPTION
Class _internal::GenericRegex<EncodingType, AllocatorType>_ is used by _internal::Schema<SchemaDocumentType>_.

The template parameter for _AllocatorType_ is left to it's default value. This pull request uses Schema::AllocatorType as template parameter and initializes the regex objects created with the schema allocator.

The goal is to use the same (custom) allocator than the one used for _SchemaDocument_. Without this patch, the allocator used is a new instance of the default  _CrtAllocator_, regardless of the allocator used for the _SchemaDocument_.