### PR TITLE
Removing Klocwork issues from schema.h

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -355,6 +355,7 @@ public:
         not_(),
         type_((1 << kTotalSchemaType) - 1), // typeless
         validatorCount_(),
+        notValidatorIndex_(),
         properties_(),
         additionalPropertiesSchema_(),
         patternProperties_(),
@@ -409,11 +410,9 @@ public:
                 }
             }
 
-        if (schemaDocument) {
-            AssignIfExist(allOf_, *schemaDocument, p, value, GetAllOfString(), document);
-            AssignIfExist(anyOf_, *schemaDocument, p, value, GetAnyOfString(), document);
-            AssignIfExist(oneOf_, *schemaDocument, p, value, GetOneOfString(), document);
-        }
+        AssignIfExist(allOf_, *schemaDocument, p, value, GetAllOfString(), document);
+        AssignIfExist(anyOf_, *schemaDocument, p, value, GetAnyOfString(), document);
+        AssignIfExist(oneOf_, *schemaDocument, p, value, GetOneOfString(), document);
 
         if (const ValueType* v = GetMember(value, GetNotString())) {
             schemaDocument->CreateSchema(&not_, p.Append(GetNotString(), allocator_), *v, document);

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -410,9 +410,11 @@ public:
                 }
             }
 
-        AssignIfExist(allOf_, *schemaDocument, p, value, GetAllOfString(), document);
-        AssignIfExist(anyOf_, *schemaDocument, p, value, GetAnyOfString(), document);
-        AssignIfExist(oneOf_, *schemaDocument, p, value, GetOneOfString(), document);
+        if (schemaDocument) {
+            AssignIfExist(allOf_, *schemaDocument, p, value, GetAllOfString(), document);
+            AssignIfExist(anyOf_, *schemaDocument, p, value, GetAnyOfString(), document);
+            AssignIfExist(oneOf_, *schemaDocument, p, value, GetOneOfString(), document);
+        }
 
         if (const ValueType* v = GetMember(value, GetNotString())) {
             schemaDocument->CreateSchema(&not_, p.Append(GetNotString(), allocator_), *v, document);


### PR DESCRIPTION
Removing Klocwork static code analysis critical issues:

line 358:
'this->notValidatorIndex_' might not be initialized in this constructor.
line :412
Pointer 'schemaDocument' checked for NULL at line 412 may be passed to function and may be dereferenced there by passing argument this to function 'CreateSchema' at line 419. Also there are 7 similar errors on lines 467 479 511 523 533 538 549.