### PR TITLE
Suggestion for issue #1108

### DIFF
--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -165,7 +165,12 @@ public:
     GenericPointer(const Token* tokens, size_t tokenCount) : allocator_(), ownAllocator_(), nameBuffer_(), tokens_(const_cast<Token*>(tokens)), tokenCount_(tokenCount), parseErrorOffset_(), parseErrorCode_(kPointerParseErrorNone) {}
 
     //! Copy constructor.
-    GenericPointer(const GenericPointer& rhs, Allocator* allocator = 0) : allocator_(allocator), ownAllocator_(), nameBuffer_(), tokens_(), tokenCount_(), parseErrorOffset_(), parseErrorCode_(kPointerParseErrorNone) {
+    GenericPointer(const GenericPointer& rhs) : allocator_(rhs.allocator_), ownAllocator_(), nameBuffer_(), tokens_(), tokenCount_(), parseErrorOffset_(), parseErrorCode_(kPointerParseErrorNone) {
+        *this = rhs;
+    }
+
+    //! Copy constructor.
+    GenericPointer(const GenericPointer& rhs, Allocator* allocator) : allocator_(allocator), ownAllocator_(), nameBuffer_(), tokens_(), tokenCount_(), parseErrorOffset_(), parseErrorCode_(kPointerParseErrorNone) {
         *this = rhs;
     }
 

--- a/test/unittest/pointertest.cpp
+++ b/test/unittest/pointertest.cpp
@@ -462,7 +462,8 @@ TEST(Pointer, ConstructorWithToken) {
 
 TEST(Pointer, CopyConstructor) {
     {
-        Pointer p("/foo/0");
+        CrtAllocator allocator;
+        Pointer p("/foo/0", &allocator);
         Pointer q(p);
         EXPECT_TRUE(q.IsValid());
         EXPECT_EQ(2u, q.GetTokenCount());
@@ -471,6 +472,7 @@ TEST(Pointer, CopyConstructor) {
         EXPECT_EQ(1u, q.GetTokens()[1].length);
         EXPECT_STREQ("0", q.GetTokens()[1].name);
         EXPECT_EQ(0u, q.GetTokens()[1].index);
+        EXPECT_EQ(&p.GetAllocator(), &q.GetAllocator());
     }
 
     // Static tokens
@@ -489,7 +491,8 @@ TEST(Pointer, CopyConstructor) {
 
 TEST(Pointer, Assignment) {
     {
-        Pointer p("/foo/0");
+        CrtAllocator allocator;
+        Pointer p("/foo/0", &allocator);
         Pointer q;
         q = p;
         EXPECT_TRUE(q.IsValid());
@@ -499,6 +502,7 @@ TEST(Pointer, Assignment) {
         EXPECT_EQ(1u, q.GetTokens()[1].length);
         EXPECT_STREQ("0", q.GetTokens()[1].name);
         EXPECT_EQ(0u, q.GetTokens()[1].index);
+        EXPECT_NE(&p.GetAllocator(), &q.GetAllocator());
         q = q;
         EXPECT_TRUE(q.IsValid());
         EXPECT_EQ(2u, q.GetTokenCount());
@@ -507,6 +511,7 @@ TEST(Pointer, Assignment) {
         EXPECT_EQ(1u, q.GetTokens()[1].length);
         EXPECT_STREQ("0", q.GetTokens()[1].name);
         EXPECT_EQ(0u, q.GetTokens()[1].index);
+        EXPECT_NE(&p.GetAllocator(), &q.GetAllocator());
     }
 
     // Static tokens


### PR DESCRIPTION
Solves #1108. The default copy constructor of GenericPointer will use the allocator of the copied object. The extra copy constructor that takes an allocator as a parameter is distinct if someone really wants to create a copy with a null allocator.

See  #1108 for details and other possible solutions.