### PR TITLE
Write RawNumber without quotes

### DIFF
--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -198,7 +198,7 @@ public:
         RAPIDJSON_ASSERT(str != 0);
         (void)copy;
         Prefix(kNumberType);
-        return EndValue(WriteString(str, length));
+        return EndValue(WriteRawNumber(str, length));
     }
 
     bool String(const Ch* str, SizeType length, bool copy = false) {
@@ -463,6 +463,15 @@ protected:
         for (size_t i = 0; i < length; i++) {
             RAPIDJSON_ASSERT(json[i] != '\0');
             PutUnsafe(*os_, json[i]);
+        }
+        return true;
+    }
+
+    bool WriteRawNumber(const Ch* json, size_t length) {
+        PutReserve(*os_, length);
+        for (size_t i = 0; i < length; i++) {
+			RAPIDJSON_ASSERT(json[i] > 0 && json[i] < 128);
+            PutUnsafe(*os_, static_cast<typename OutputStream::Ch>(json[i]));
         }
         return true;
     }

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -470,7 +470,7 @@ protected:
     bool WriteRawNumber(const Ch* json, size_t length) {
         PutReserve(*os_, length);
         for (size_t i = 0; i < length; i++) {
-			RAPIDJSON_ASSERT(json[i] > 0 && json[i] < 128);
+            RAPIDJSON_ASSERT(json[i] > 0 && json[i] < 128);
             PutUnsafe(*os_, static_cast<typename OutputStream::Ch>(json[i]));
         }
         return true;

--- a/test/unittest/writertest.cpp
+++ b/test/unittest/writertest.cpp
@@ -538,6 +538,18 @@ TEST(Writer, RawValue) {
     EXPECT_STREQ("{\"a\":1,\"raw\":[\"Hello\\nWorld\", 123.456]}", buffer.GetString());
 }
 
+TEST(Writer, RawNumber) {
+    StringBuffer buffer;
+    Writer<StringBuffer> writer(buffer);
+    writer.StartArray();
+    const char number[] = "3.14159";
+    writer.RawNumber(number, 4);
+    writer.RawNumber(number, static_cast<SizeType>(strlen(number)));
+    writer.EndArray();
+    EXPECT_TRUE(writer.IsComplete());
+    EXPECT_STREQ("[3.14,3.14159]", buffer.GetString());
+}
+
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
 static Writer<StringBuffer> WriterGen(StringBuffer &target) {
     Writer<StringBuffer> writer(target);


### PR DESCRIPTION
This PR try to fix issue that `Writer.RawNumber()` writes number as string with quotes (#560 #704 #852). Some Considerations:
1. Raw number should contain characters in range [1,127], so it's safe that cast it to `OutputStream::Ch`.
2. No futher checking as `WriteRawValue()`.