### PR TITLE
Fix compilation error of archivertest.cpp due to -Werr=effc++

### DIFF
--- a/example/archiver/archivertest.cpp
+++ b/example/archiver/archivertest.cpp
@@ -6,6 +6,22 @@
 // Test1: simple object
 
 struct Student {
+    Student()
+      : name(),
+        age(0),
+        height(0.0),
+        canSwim(false)
+    {}
+
+    Student(const std::string& name,
+            unsigned age,
+            double height,
+            bool canSwim)
+      : name(name),
+        age(age),
+        height(height),
+        canSwim(canSwim)
+    {}
     std::string name;
     unsigned age;
     double height;
@@ -31,7 +47,7 @@ void test1() {
 
     // Serialize
     {
-        Student s = { "Lua", 9, 150.5, true };
+        Student s { "Lua", 9, 150.5, true };
 
         JsonWriter writer;
         writer & s;
@@ -50,10 +66,14 @@ void test1() {
 
 //////////////////////////////////////////////////////////////////////////////
 // Test2: std::vector <=> JSON array
-// 
+//
 // You can map a JSON array to other data structures as well
 
 struct Group {
+    Group()
+      : groupName(),
+        students()
+    {}
     std::string groupName;
     std::vector<Student> students;
 };
@@ -61,7 +81,7 @@ struct Group {
 template <typename Archiver>
 Archiver& operator&(Archiver& ar, Group& g) {
     ar.StartObject();
-    
+
     ar.Member("groupName");
     ar & g.groupName;
 
@@ -124,7 +144,7 @@ public:
     virtual void Print(std::ostream& os) const = 0;
 
 protected:
-    Shape() {}
+    Shape() : x_(), y_() {}
     Shape(double x, double y) : x_(x), y_(y) {}
 
     template <typename Archiver>
@@ -142,7 +162,7 @@ Archiver& operator&(Archiver& ar, Shape& s) {
 
 class Circle : public Shape {
 public:
-    Circle() {}
+    Circle() : Shape(), radius_() {}
     Circle(double x, double y, double radius) : Shape(x, y), radius_(radius) {}
     ~Circle() {}
 
@@ -168,7 +188,7 @@ Archiver& operator&(Archiver& ar, Circle& c) {
 
 class Box : public Shape {
 public:
-    Box() {}
+    Box() : Shape(), width_(), height_() {}
     Box(double x, double y, double width, double height) : Shape(x, y), width_(width), height_(height) {}
     ~Box() {}
 
@@ -195,16 +215,16 @@ Archiver& operator&(Archiver& ar, Box& b) {
 
 class Canvas {
 public:
-    Canvas() {}
+    Canvas() : shapes_() {}
     ~Canvas() { Clear(); }
-    
+
     void Clear() {
         for (std::vector<Shape*>::iterator itr = shapes_.begin(); itr != shapes_.end(); ++itr)
             delete *itr;
     }
 
     void AddShape(Shape* shape) { shapes_.push_back(shape); }
-    
+
     void Print(std::ostream& os) {
         for (std::vector<Shape*>::iterator itr = shapes_.begin(); itr != shapes_.end(); ++itr) {
             (*itr)->Print(os);


### PR DESCRIPTION
This solved the compilation error I have on Debian SID / gcc version 7.3.0

```
/home/stac/development/rapidjson/example/archiver/archivertest.cpp: In function ‘void test1()’:                                                                                                                                                /home/stac/development/rapidjson/example/archiver/archivertest.cpp:40:45: error: could not convert ‘{"Lua", 9, 1.505e+2, true}’ from ‘<brace-enclosed initializer list>’ to ‘Student’                                                                   Student s = { "Lua", 9, 150.5, true };                                                                                                                                                                                                                                             ^                                                                                                                                                                                                 /home/stac/development/rapidjson/example/archiver/archivertest.cpp: In constructor ‘Group::Group()’:                                         
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:62:8: error: ‘Group::groupName’ should be initialized in the member initialization list [-Werror=effc++]
 struct Group {                                                                                       
        ^~~~~                                                                                                                                                              
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:62:8: error: ‘Group::students’ should be initialized in the member initialization list [-Werror=effc++]
/home/stac/development/rapidjson/example/archiver/archivertest.cpp: In function ‘void test2()’:
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:98:15: note: synthesized method ‘Group::Group()’ first required here
         Group g;
               ^
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:101:46: error: could not convert ‘{"Lua", 9, 1.505e+2, true}’ from ‘<brace-enclosed initializer list>’ to ‘Student’
         Student s1 = { "Lua", 9, 150.5, true };
                                              ^
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:102:47: error: could not convert ‘{"Mio", 7, 1.2e+2, false}’ from ‘<brace-enclosed initializer list>’ to ‘Student’
         Student s2 = { "Mio", 7, 120.0, false };
                                               ^
/home/stac/development/rapidjson/example/archiver/archivertest.cpp: In constructor ‘Shape::Shape()’:
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:133:5: error: ‘Shape::x_’ should be initialized in the member initialization list [-Werror=effc++]
     Shape() {}
     ^~~~~
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:133:5: error: ‘Shape::y_’ should be initialized in the member initialization list [-Werror=effc++]
/home/stac/development/rapidjson/example/archiver/archivertest.cpp: In constructor ‘Circle::Circle()’:
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:151:5: error: ‘Circle::radius_’ should be initialized in the member initialization list [-Werror=effc++]
     Circle() {}
     ^~~~~~
/home/stac/development/rapidjson/example/archiver/archivertest.cpp: In constructor ‘Box::Box()’:
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:177:5: error: ‘Box::width_’ should be initialized in the member initialization list [-Werror=effc++]
     Box() {}
     ^~~
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:177:5: error: ‘Box::height_’ should be initialized in the member initialization list [-Werror=effc++]
/home/stac/development/rapidjson/example/archiver/archivertest.cpp: In constructor ‘Canvas::Canvas()’:
/home/stac/development/rapidjson/example/archiver/archivertest.cpp:204:5: error: ‘Canvas::shapes_’ should be initialized in the member initialization list [-Werror=effc++]
     Canvas() {}
     ^~~~~~
cc1plus: all warnings being treated as errors
example/CMakeFiles/archivertest.dir/build.make:86: recipe for target 'example/CMakeFiles/archivertest.dir/archiver/archivertest.cpp.o' failed
make[2]: *** [example/CMakeFiles/archivertest.dir/archiver/archivertest.cpp.o] Error 1
CMakeFiles/Makefile2:1379: recipe for target 'example/CMakeFiles/archivertest.dir/all' failed
make[1]: *** [example/CMakeFiles/archivertest.dir/all] Error 2
Makefile:140: recipe for target 'all' failed
make: *** [all] Error 2
zsh: exit 2     make
```
