### PR TITLE
Support long and unsined long as int and unsigned on Microsft platforms

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -451,6 +451,26 @@ struct TypeHelper<ValueType, unsigned> {
     static ValueType& Set(ValueType& v, unsigned data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
 };
 
+#ifdef _MSC_VER
+RAPIDJSON_STATIC_ASSERT(sizeof(long) == sizeof(int));
+template<typename ValueType>
+struct TypeHelper<ValueType, long> {
+    static bool Is(const ValueType& v) { return v.IsInt(); }
+    static long Get(const ValueType& v) { return v.GetInt(); }
+    static ValueType& Set(ValueType& v, long data) { return v.SetInt(data); }
+    static ValueType& Set(ValueType& v, long data, typename ValueType::AllocatorType&) { return v.SetInt(data); }
+};
+
+RAPIDJSON_STATIC_ASSERT(sizeof(unsigned long) == sizeof(unsigned));
+template<typename ValueType>
+struct TypeHelper<ValueType, unsigned long> {
+    static bool Is(const ValueType& v) { return v.IsUint(); }
+    static unsigned long Get(const ValueType& v) { return v.GetUint(); }
+    static ValueType& Set(ValueType& v, unsigned long data) { return v.SetUint(data); }
+    static ValueType& Set(ValueType& v, unsigned long data, typename ValueType::AllocatorType&) { return v.SetUint(data); }
+};
+#endif
+
 template<typename ValueType> 
 struct TypeHelper<ValueType, int64_t> {
     static bool Is(const ValueType& v) { return v.IsInt64(); }

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -499,7 +499,7 @@ TEST(Value, Uint) {
     RAPIDJSON_STATIC_ASSERT(sizeof(unsigned long) == sizeof(unsigned));
     z.SetUint(1234);
     EXPECT_TRUE(z.Is<unsigned long>());
-    EXPECT_EQ(1234ul, z.Get<unsigned>());
+    EXPECT_EQ(1234ul, z.Get<unsigned long>());
 #endif
 }
 

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -439,6 +439,14 @@ TEST(Value, Int) {
     EXPECT_EQ(5678, z.Get<int>());
     EXPECT_EQ(5679, z.Set(5679).Get<int>());
     EXPECT_EQ(5680, z.Set<int>(5680).Get<int>());
+
+#ifdef _MSC_VER
+    // long as int on MSC platforms
+    RAPIDJSON_STATIC_ASSERT(sizeof(long) == sizeof(int));
+    z.SetInt(1234);
+    EXPECT_TRUE(z.Is<long>());
+    EXPECT_EQ(1234l, z.Get<long>());
+#endif
 }
 
 TEST(Value, Uint) {
@@ -485,6 +493,14 @@ TEST(Value, Uint) {
     EXPECT_EQ(2147483648u, z.Get<unsigned>());
     EXPECT_EQ(2147483649u, z.Set(2147483649u).Get<unsigned>());
     EXPECT_EQ(2147483650u, z.Set<unsigned>(2147483650u).Get<unsigned>());
+
+#ifdef _MSC_VER
+    // unsigned long as unsigned on MSC platforms
+    RAPIDJSON_STATIC_ASSERT(sizeof(unsigned long) == sizeof(unsigned));
+    z.SetUint(1234);
+    EXPECT_TRUE(z.Is<unsigned long>());
+    EXPECT_EQ(1234ul, z.Get<unsigned>());
+#endif
 }
 
 TEST(Value, Int64) {


### PR DESCRIPTION
We are still using long and unsigned long as s32 and u32 on Microsoft platforms and it was not supported by the TypeHelper.

I added support for long and unsigned long to be Int and UInt when _MSC_VER is definded.
I also added static assert to validate long and unsigned long size in case one day Microsoft change its mind.