### PR TITLE
Fixes #1198

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1860,7 +1860,12 @@ public:
 
     //! Gets the JSON pointer pointed to the invalid value.
     PointerType GetInvalidDocumentPointer() const {
-        return documentStack_.Empty() ? PointerType() : PointerType(documentStack_.template Bottom<Ch>(), documentStack_.GetSize() / sizeof(Ch));
+        if (documentStack_.Empty()) {
+            return PointerType();
+        }
+        else {
+            return PointerType(documentStack_.template Bottom<Ch>(), documentStack_.GetSize() / sizeof(Ch));
+        }
     }
 
     void NotMultipleOf(int64_t actual, const SValue& expected) {


### PR DESCRIPTION
Problem: unit test fails unit at SchemaValidator.TestSuite with additionalItems.json on Windows build with VS2010 (possibly with others)

Resolution: changed return value format.

This PR is supposed to repair Appveyor Windows builds that seem to be half-broken since some time.