### PR TITLE
Ensure a preprocessor directive is only applied to MSVC.

### DIFF
--- a/include/rapidjson/internal/biginteger.h
+++ b/include/rapidjson/internal/biginteger.h
@@ -17,7 +17,7 @@
 
 #include "../rapidjson.h"
 
-#if defined(_MSC_VER) && defined(_M_AMD64)
+#if defined(_MSC_VER) && !__INTEL_COMPILER && defined(_M_AMD64)
 #include <intrin.h> // for _umul128
 #pragma intrinsic(_umul128)
 #endif


### PR DESCRIPTION
The `#pragma intrinsic` preprocessor directive is only implemented on the MSVC compiler. However, the Intel compiler defines `_MSC_VER` to be compatible with MSVC. This results in the following warning when compiling using Intel: `unimplemented pragma ignored` every time the `biginteger.h` file is included.