### PR TITLE
add remote ref pointer to schemaMap_

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1673,6 +1673,7 @@ private:
                                 if (const SchemaType* sc = remoteDocument->GetSchema(pointer)) {
                                     if (schema)
                                         *schema = sc;
+                                    new (schemaMap_.template Push<SchemaEntry>()) SchemaEntry(source, const_cast<SchemaType*>(sc), false, allocator_);
                                     return true;
                                 }
                             }

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -2015,7 +2015,7 @@ TEST(SchemaValidator, Ref_remote_issue1210) {
             return collection[i];
           }
     };
-    SchemaDocument* collection[] { 0, 0, 0 };
+    SchemaDocument* collection[] = { 0, 0, 0 };
     SchemaDocumentProvider provider(collection);
 
     Document x, y, z;

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -2011,7 +2011,7 @@ TEST(SchemaValidator, Ref_remote_issue1210) {
           SchemaDocumentProvider(SchemaDocument** collection) : collection(collection) { }
           virtual const SchemaDocument* GetRemoteDocument(const char* uri, SizeType length) {
             int i = 0;
-            while (collection[i] && typename SchemaDocument::URIType(uri, length) != collection[i]->GetURI()) ++i;
+            while (collection[i] && SchemaDocument::URIType(uri, length) != collection[i]->GetURI()) ++i;
             return collection[i];
           }
     };

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -2004,6 +2004,35 @@ TEST(SchemaValidator, Ref_remote) {
         SchemaValidatorType, PointerType);
 }
 
+TEST(SchemaValidator, Ref_remote_issue1210) {
+    class SchemaDocumentProvider : public IRemoteSchemaDocumentProvider {
+        SchemaDocument** collection;
+        public:
+          SchemaDocumentProvider(SchemaDocument** collection) : collection(collection) { }
+          virtual const SchemaDocument* GetRemoteDocument(const char* uri, SizeType length) {
+            int i = 0;
+            while (collection[i] && typename SchemaDocument::URIType(uri, length) != collection[i]->GetURI()) ++i;
+            return collection[i];
+          }
+    };
+    SchemaDocument* collection[] { 0, 0, 0 };
+    SchemaDocumentProvider provider(collection);
+
+    Document x, y, z;
+    x.Parse("{\"properties\":{\"country\":{\"$ref\":\"y.json#/definitions/country_remote\"}},\"type\":\"object\"}");
+    y.Parse("{\"definitions\":{\"country_remote\":{\"$ref\":\"z.json#/definitions/country_list\"}}}");
+    z.Parse("{\"definitions\":{\"country_list\":{\"enum\":[\"US\"]}}}");
+
+    SchemaDocument sz(z, "z.json", 6, &provider);
+    collection[0] = &sz;
+    SchemaDocument sy(y, "y.json", 6, &provider);
+    collection[1] = &sy;
+    SchemaDocument sx(x, "x.json", 6, &provider);
+
+    VALIDATE(sx, "{\"country\":\"UK\"}", false);
+    VALIDATE(sx, "{\"country\":\"US\"}", true);
+}
+
 #ifdef __clang__
 RAPIDJSON_DIAG_POP
 #endif


### PR DESCRIPTION
Hello,

I think I've encountered a bug. I noticed wrong results when validating a schema referencing a remote schema, which references another remote schema. Here is an example: https://gist.github.com/foxtacles/0deaa03be09cf9820e49cc590ee020c6

`x.json` references `y.json` references `z.json`. The validation should fail (`UK` is not part of the `enum`). However, it succeeds in the current `master` version of RapidJSON.

I found this is because in the `HandleRefSchema` function, `remoteDocument->GetSchema(pointer)` returns a null pointer. In the case of `y.json`, the pointer `/definitions/country` is not part of the internal `schemaMap_`.  Since RapidJSON silently ignores this, the validation succeeds.

I'm not sure if this is intended behaviour - maybe I'm using the library in some wrong way, but I've attached a fix that resolves this problem (storing the schema pointer with a non-owning pointer to the remote schema).

Thanks for your great work!