### PR TITLE
Prevent int underflow when parsing exponents

### DIFF
--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -242,6 +242,7 @@ static void TestParseDouble() {
     TEST_DOUBLE(fullPrecision, "1e-214748363", 0.0);                                  // Maximum supported negative exponent
     TEST_DOUBLE(fullPrecision, "1e-214748364", 0.0);
     TEST_DOUBLE(fullPrecision, "1e-21474836311", 0.0);
+    TEST_DOUBLE(fullPrecision, "1.00000000001e-2147483638", 0.0);
     TEST_DOUBLE(fullPrecision, "0.017976931348623157e+310", 1.7976931348623157e+308); // Max double in another form
 
     // Since


### PR DESCRIPTION
When parsing negative exponents, the current implementation takes
precautions for |exp| to not underflow int.

But that is not sufficient: later on [1], |exp + expFrac| is also
stored to an int - so we must ensure that the sum stays within int
representable values.

Update the exp clamping logic to take expFrac into account.

[1] https://github.com/Tencent/rapidjson/blob/master/include/rapidjson/reader.h#L1690