### PR TITLE
Avoid `MissingProperty` Error from `SchemaValidator` when a none-zero length value is given as `default` for the property

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -441,7 +441,7 @@ public:
         maxLength_(~SizeType(0)),
         exclusiveMinimum_(false),
         exclusiveMaximum_(false),
-        defaultValue_()
+        defaultValueLength_(0)
     {
         typedef typename SchemaDocumentType::ValueType ValueType;
         typedef typename ValueType::ConstValueIterator ConstValueIterator;
@@ -640,7 +640,7 @@ public:
         // Default
         if (const ValueType* v = GetMember(value, GetDefaultValueString()))
             if (v->IsString())
-                defaultValue_ = v->GetString();
+                defaultValueLength_ = v->GetStringLength();
 
     }
 
@@ -942,14 +942,9 @@ public:
         if (hasRequired_) {
             context.error_handler.StartMissingProperties();
             for (SizeType index = 0; index < propertyCount_; index++)
-                if (properties_[index].required && !context.propertyExist[index]){
-                    if (properties_[index].schema->defaultValue_.empty() || properties_[index].schema->defaultValue_ == "" ){
+                if (properties_[index].required && !context.propertyExist[index])
+                    if (properties_[index].schema->defaultValueLength_ == 0 )
                         context.error_handler.AddMissingProperty(properties_[index].name);
-                    } else {
-                        // std::cout << "default value of " << properties_[index].name.GetString()
-                        //             <<  " is:" << properties_[index].schema->defaultValue_ << "\n";
-                    }
-                }
             if (context.error_handler.EndMissingProperties())
                 RAPIDJSON_INVALID_KEYWORD_RETURN(GetRequiredString());
         }
@@ -1441,7 +1436,7 @@ private:
     bool exclusiveMinimum_;
     bool exclusiveMaximum_;
     
-    std::string defaultValue_;
+    SizeType defaultValueLength_;
 };
 
 template<typename Stack, typename Ch>

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -1049,6 +1049,33 @@ TEST(SchemaValidator, Object_Required) {
         "}}");
 }
 
+TEST(SchemaValidator, Object_Required_PassWithDefault) {
+    Document sd;
+    sd.Parse(
+        "{"
+        "    \"type\": \"object\","
+        "    \"properties\" : {"
+        "        \"name\":      { \"type\": \"string\", \"default\": \"William Shakespeare\" },"
+        "        \"email\" : { \"type\": \"string\", \"default\": \"\" },"
+        "        \"address\" : { \"type\": \"string\" },"
+        "        \"telephone\" : { \"type\": \"string\" }"
+        "    },"
+        "    \"required\":[\"name\", \"email\"]"
+        "}");
+    SchemaDocument s(sd);
+
+    VALIDATE(s, "{ \"email\" : \"bill@stratford-upon-avon.co.uk\", \"address\" : \"Henley Street, Stratford-upon-Avon, Warwickshire, England\", \"authorship\" : \"in question\"}", true);
+    INVALIDATE(s, "{ \"name\": \"William Shakespeare\", \"address\" : \"Henley Street, Stratford-upon-Avon, Warwickshire, England\" }", "", "required", "",
+        "{ \"required\": {"
+        "    \"instanceRef\": \"#\", \"schemaRef\": \"#\","
+        "    \"missing\": [\"email\"]"
+        "}}");
+    INVALIDATE(s, "{}", "", "required", "",
+        "{ \"required\": {"
+        "    \"instanceRef\": \"#\", \"schemaRef\": \"#\","
+        "    \"missing\": [\"email\"]"
+        "}}");
+}
 
 TEST(SchemaValidator, Object_PropertiesRange) {
     Document sd;


### PR DESCRIPTION
In relation to issue #784 : this pull request enables the `SchemaValidator` to recognise the `default` keyword of a JSON schema, so that:

1. When a none-zero string is given as `default` for a property, a `MissingProperty` error is avoided;
2. The actual content of the string given by the `default` keyword is not checked by the schema at all, only the length of the string is concerned;
3. No modification (such as requested by #784) to the actual JSON document object is made. The programmer is still left with the task to check if the property exist in the document, and if and when `default` is needed, what `default` value it has (by reading the schema document object) .