### PR TITLE
Handle non-throwing exception specifications that can still throw #1280

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -629,7 +629,7 @@ public:
             kNullFlag, kFalseFlag, kTrueFlag, kObjectFlag, kArrayFlag, kShortStringFlag,
             kNumberAnyFlag
         };
-        RAPIDJSON_ASSERT(type >= kNullType && type <= kNumberType);
+        RAPIDJSON_NOEXCEPT_ASSERT(type >= kNullType && type <= kNumberType);
         data_.f.flags = defaultFlags[type];
 
         // Use ShortString to store empty string.
@@ -831,9 +831,10 @@ public:
     /*! \param rhs Source of the assignment. It will become a null value after assignment.
     */
     GenericValue& operator=(GenericValue& rhs) RAPIDJSON_NOEXCEPT {
-        RAPIDJSON_ASSERT(this != &rhs);
-        this->~GenericValue();
-        RawAssign(rhs);
+        if (this != &rhs) {
+            this->~GenericValue();
+            RawAssign(rhs);
+        }
         return *this;
     }
 

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -592,6 +592,19 @@ RAPIDJSON_NAMESPACE_END
 //!@endcond
 
 ///////////////////////////////////////////////////////////////////////////////
+// RAPIDJSON_NOEXCEPT_ASSERT
+
+#ifdef RAPIDJSON_ASSERT_THROWS
+#if RAPIDJSON_HAS_CXX11_NOEXCEPT
+#define RAPIDJSON_NOEXCEPT_ASSERT(x)
+#else
+#define RAPIDJSON_NOEXCEPT_ASSERT(x) RAPIDJSON_ASSERT(x)
+#endif // RAPIDJSON_HAS_CXX11_NOEXCEPT
+#else
+#define RAPIDJSON_NOEXCEPT_ASSERT(x) RAPIDJSON_ASSERT(x)
+#endif // RAPIDJSON_ASSERT_THROWS
+
+///////////////////////////////////////////////////////////////////////////////
 // new/delete
 
 #ifndef RAPIDJSON_NEW


### PR DESCRIPTION
This is to address https://github.com/Tencent/rapidjson/issues/1280

Note that I have opted a means to control if this is applied or not through RAPIDJSON_ASSERT_THROWS

Example usage in my code setting this is

```
#define RAPIDJSON_ASSERT_THROWS 1

#define RAPIDJSON_ASSERT(x) if (!(x)) throw RapidJsonException();
```