### PR TITLE
Fix the compiling problems in VS

### DIFF
--- a/test/perftest/platformtest.cpp
+++ b/test/perftest/platformtest.cpp
@@ -76,7 +76,7 @@ TEST_F(Platform, strlen) {
 
 TEST_F(Platform, memcmp) {
     for (int i = 0; i < kTrialCount; i++) {
-        EXPECT_EQ(0, memcmp(temp_, json_, length_));
+        EXPECT_EQ(0u, memcmp(temp_, json_, length_));
     }
 }
 

--- a/test/unittest/cursorstreamwrappertest.cpp
+++ b/test/unittest/cursorstreamwrappertest.cpp
@@ -38,8 +38,8 @@ TEST(CursorStreamWrapper, MissingFirstBracket) {
     size_t col, line;
     bool ret = testJson(json, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 3);
-    EXPECT_EQ(col, 0);
+    EXPECT_EQ(line, 3u);
+    EXPECT_EQ(col, 0u);
 }
 
 TEST(CursorStreamWrapper, MissingQuotes) {
@@ -47,8 +47,8 @@ TEST(CursorStreamWrapper, MissingQuotes) {
     size_t col, line;
     bool ret = testJson(json, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 1);
-    EXPECT_EQ(col, 8);
+    EXPECT_EQ(line, 1u);
+    EXPECT_EQ(col, 8u);
 }
 
 TEST(CursorStreamWrapper, MissingColon) {
@@ -56,8 +56,8 @@ TEST(CursorStreamWrapper, MissingColon) {
     size_t col, line;
     bool ret = testJson(json, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 3);
-    EXPECT_EQ(col, 0);
+    EXPECT_EQ(line, 3u);
+    EXPECT_EQ(col, 0u);
 }
 
 TEST(CursorStreamWrapper, MissingSecondQuotes) {
@@ -65,8 +65,8 @@ TEST(CursorStreamWrapper, MissingSecondQuotes) {
     size_t col, line;
     bool ret = testJson(json, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 3);
-    EXPECT_EQ(col, 1);
+    EXPECT_EQ(line, 3u);
+    EXPECT_EQ(col, 1u);
 }
 
 TEST(CursorStreamWrapper, MissingComma) {
@@ -74,8 +74,8 @@ TEST(CursorStreamWrapper, MissingComma) {
     size_t col, line;
     bool ret = testJson(json, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 3);
-    EXPECT_EQ(col, 12);
+    EXPECT_EQ(line, 3u);
+    EXPECT_EQ(col, 12u);
 }
 
 TEST(CursorStreamWrapper, MissingArrayBracket) {
@@ -83,8 +83,8 @@ TEST(CursorStreamWrapper, MissingArrayBracket) {
     size_t col, line;
     bool ret = testJson(json, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 4);
-    EXPECT_EQ(col, 9);
+    EXPECT_EQ(line, 4u);
+    EXPECT_EQ(col, 9u);
 }
 
 TEST(CursorStreamWrapper, MissingArrayComma) {
@@ -92,8 +92,8 @@ TEST(CursorStreamWrapper, MissingArrayComma) {
     size_t col, line;
     bool ret = testJson(json, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 4);
-    EXPECT_EQ(col, 6);
+    EXPECT_EQ(line, 4u);
+    EXPECT_EQ(col, 6u);
 }
 
 TEST(CursorStreamWrapper, MissingLastArrayBracket) {
@@ -101,8 +101,8 @@ TEST(CursorStreamWrapper, MissingLastArrayBracket) {
     size_t col, line;
     bool ret = testJson(json8, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 4);
-    EXPECT_EQ(col, 15);
+    EXPECT_EQ(line, 4u);
+    EXPECT_EQ(col, 15u);
 }
 
 TEST(CursorStreamWrapper, MissingLastBracket) {
@@ -110,6 +110,6 @@ TEST(CursorStreamWrapper, MissingLastBracket) {
     size_t col, line;
     bool ret = testJson(json9, line, col);
     EXPECT_TRUE(ret);
-    EXPECT_EQ(line, 4);
-    EXPECT_EQ(col, 16);
+    EXPECT_EQ(line, 4u);
+    EXPECT_EQ(col, 16u);
 }

--- a/test/unittest/istreamwrappertest.cpp
+++ b/test/unittest/istreamwrappertest.cpp
@@ -35,21 +35,21 @@ static void TestStringStream() {
     {
         StringStreamType iss;
         BasicIStreamWrapper<StringStreamType> is(iss);
-        EXPECT_EQ(0, is.Tell());
+        EXPECT_EQ(0u, is.Tell());
         if (sizeof(Ch) == 1) {
             EXPECT_EQ(0, is.Peek4());
-            EXPECT_EQ(0, is.Tell());
+            EXPECT_EQ(0u, is.Tell());
         }
         EXPECT_EQ(0, is.Peek());
         EXPECT_EQ(0, is.Take());
-        EXPECT_EQ(0, is.Tell());
+        EXPECT_EQ(0u, is.Tell());
     }
 
     {
         Ch s[] = { 'A', 'B', 'C', '\0' };
         StringStreamType iss(s);
         BasicIStreamWrapper<StringStreamType> is(iss);
-        EXPECT_EQ(0, is.Tell());
+        EXPECT_EQ(0u, is.Tell());
         if (sizeof(Ch) == 1) {
             EXPECT_EQ(0, is.Peek4()); // less than 4 bytes
         }
@@ -59,7 +59,7 @@ static void TestStringStream() {
             EXPECT_EQ('A' + i, is.Peek());
             EXPECT_EQ('A' + i, is.Take());
         }
-        EXPECT_EQ(3, is.Tell());
+        EXPECT_EQ(3u, is.Tell());
         EXPECT_EQ(0, is.Peek());
         EXPECT_EQ(0, is.Take());
     }
@@ -72,7 +72,7 @@ static void TestStringStream() {
             const Ch* c = is.Peek4();
             for (int i = 0; i < 4; i++)
                 EXPECT_EQ('A' + i, c[i]);
-            EXPECT_EQ(0, is.Tell());
+            EXPECT_EQ(0u, is.Tell());
         }
         for (int i = 0; i < 5; i++) {
             EXPECT_EQ(static_cast<size_t>(i), is.Tell());
@@ -80,7 +80,7 @@ static void TestStringStream() {
             EXPECT_EQ('A' + i, is.Peek());
             EXPECT_EQ('A' + i, is.Take());
         }
-        EXPECT_EQ(5, is.Tell());
+        EXPECT_EQ(5u, is.Tell());
         EXPECT_EQ(0, is.Peek());
         EXPECT_EQ(0, is.Take());
     }
@@ -129,7 +129,7 @@ TEST(IStreamWrapper, ifstream) {
     Document d;
     EXPECT_TRUE(!d.ParseStream(eis).HasParseError());
     EXPECT_TRUE(d.IsObject());
-    EXPECT_EQ(5, d.MemberCount());
+    EXPECT_EQ(5u, d.MemberCount());
 }
 
 TEST(IStreamWrapper, fstream) {
@@ -140,7 +140,7 @@ TEST(IStreamWrapper, fstream) {
     Document d;
     EXPECT_TRUE(!d.ParseStream(eis).HasParseError());
     EXPECT_TRUE(d.IsObject());
-    EXPECT_EQ(5, d.MemberCount());
+    EXPECT_EQ(5u, d.MemberCount());
 }
 
 // wifstream/wfstream only works on C++11 with codecvt_utf16

--- a/test/unittest/pointertest.cpp
+++ b/test/unittest/pointertest.cpp
@@ -634,13 +634,13 @@ TEST(Pointer, Get) {
     EXPECT_TRUE(Pointer("/abc").Get(d) == 0);
     size_t unresolvedTokenIndex;
     EXPECT_TRUE(Pointer("/foo/2").Get(d, &unresolvedTokenIndex) == 0); // Out of boundary
-    EXPECT_EQ(1, unresolvedTokenIndex);
+    EXPECT_EQ(1u, unresolvedTokenIndex);
     EXPECT_TRUE(Pointer("/foo/a").Get(d, &unresolvedTokenIndex) == 0); // "/foo" is an array, cannot query by "a"
-    EXPECT_EQ(1, unresolvedTokenIndex);
+    EXPECT_EQ(1u, unresolvedTokenIndex);
     EXPECT_TRUE(Pointer("/foo/0/0").Get(d, &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
-    EXPECT_EQ(2, unresolvedTokenIndex);
+    EXPECT_EQ(2u, unresolvedTokenIndex);
     EXPECT_TRUE(Pointer("/foo/0/a").Get(d, &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
-    EXPECT_EQ(2, unresolvedTokenIndex);
+    EXPECT_EQ(2u, unresolvedTokenIndex);
 }
 
 TEST(Pointer, GetWithDefault) {
@@ -959,13 +959,13 @@ TEST(Pointer, GetValueByPointer) {
 
     size_t unresolvedTokenIndex;
     EXPECT_TRUE(GetValueByPointer(d, "/foo/2", &unresolvedTokenIndex) == 0); // Out of boundary
-    EXPECT_EQ(1, unresolvedTokenIndex);
+    EXPECT_EQ(1u, unresolvedTokenIndex);
     EXPECT_TRUE(GetValueByPointer(d, "/foo/a", &unresolvedTokenIndex) == 0); // "/foo" is an array, cannot query by "a"
-    EXPECT_EQ(1, unresolvedTokenIndex);
+    EXPECT_EQ(1u, unresolvedTokenIndex);
     EXPECT_TRUE(GetValueByPointer(d, "/foo/0/0", &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
-    EXPECT_EQ(2, unresolvedTokenIndex);
+    EXPECT_EQ(2u, unresolvedTokenIndex);
     EXPECT_TRUE(GetValueByPointer(d, "/foo/0/a", &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
-    EXPECT_EQ(2, unresolvedTokenIndex);
+    EXPECT_EQ(2u, unresolvedTokenIndex);
 
     // const version
     const Value& v = d;
@@ -973,13 +973,13 @@ TEST(Pointer, GetValueByPointer) {
     EXPECT_EQ(&d["foo"][0], GetValueByPointer(v, "/foo/0"));
 
     EXPECT_TRUE(GetValueByPointer(v, "/foo/2", &unresolvedTokenIndex) == 0); // Out of boundary
-    EXPECT_EQ(1, unresolvedTokenIndex);
+    EXPECT_EQ(1u, unresolvedTokenIndex);
     EXPECT_TRUE(GetValueByPointer(v, "/foo/a", &unresolvedTokenIndex) == 0); // "/foo" is an array, cannot query by "a"
-    EXPECT_EQ(1, unresolvedTokenIndex);
+    EXPECT_EQ(1u, unresolvedTokenIndex);
     EXPECT_TRUE(GetValueByPointer(v, "/foo/0/0", &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
-    EXPECT_EQ(2, unresolvedTokenIndex);
+    EXPECT_EQ(2u, unresolvedTokenIndex);
     EXPECT_TRUE(GetValueByPointer(v, "/foo/0/a", &unresolvedTokenIndex) == 0); // "/foo/0" is an string, cannot further query
-    EXPECT_EQ(2, unresolvedTokenIndex);
+    EXPECT_EQ(2u, unresolvedTokenIndex);
 
 }
 

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -649,43 +649,43 @@ static void TestParseNumberError() {
         for (int i = 1; i < 310; i++)
             n1e309[i] = '0';
         n1e309[310] = '\0';
-        TEST_NUMBER_ERROR(kParseErrorNumberTooBig, n1e309, 0, 310);
+        TEST_NUMBER_ERROR(kParseErrorNumberTooBig, n1e309, 0u, 310u);
     }
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e309", 0, 5);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e309", 0u, 5u);
 
     // Miss fraction part in number.
-    TEST_NUMBER_ERROR(kParseErrorNumberMissFraction, "1.", 2, 2);
-    TEST_NUMBER_ERROR(kParseErrorNumberMissFraction, "1.a", 2, 2);
+    TEST_NUMBER_ERROR(kParseErrorNumberMissFraction, "1.", 2u, 2u);
+    TEST_NUMBER_ERROR(kParseErrorNumberMissFraction, "1.a", 2u, 2u);
 
     // Miss exponent in number.
-    TEST_NUMBER_ERROR(kParseErrorNumberMissExponent, "1e", 2, 2);
-    TEST_NUMBER_ERROR(kParseErrorNumberMissExponent, "1e_", 2, 2);
+    TEST_NUMBER_ERROR(kParseErrorNumberMissExponent, "1e", 2u, 2u);
+    TEST_NUMBER_ERROR(kParseErrorNumberMissExponent, "1e_", 2u, 2u);
 
     // Issue 849
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1.8e308", 0, 7);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "5e308", 0, 5);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e309", 0, 5);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1.0e310", 0, 7);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1.00e310", 0, 8);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "-1.8e308", 0, 8);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "-1e309", 0, 6);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1.8e308", 0u, 7u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "5e308", 0u, 5u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e309", 0u, 5u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1.0e310", 0u, 7u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1.00e310", 0u, 8u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "-1.8e308", 0u, 8u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "-1e309", 0u, 6u);
 
     // Issue 1253
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "2e308", 0, 5);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "2e308", 0u, 5u);
 
     // Issue 1259
     TEST_NUMBER_ERROR(kParseErrorNumberTooBig,
         "88474320368547737236837236775298547354737253685475547552933720368546854775297525"
         "29337203685468547770151233720097201372368547312337203687203685423685123372036872"
         "03685473724737236837236775297525854775297525472975254737236873720170151235473783"
-        "7236737247372368772473723683723456789012E66", 0, 283);
+        "7236737247372368772473723683723456789012E66", 0u, 283u);
 
 #if 0
     // Test (length + exponent) overflow
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e+2147483647", 0, 13);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e+9223372036854775807", 0, 22);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e+10000", 0, 8);
-    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e+50000", 0, 8);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e+2147483647", 0u, 13u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e+9223372036854775807", 0u, 22u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e+10000", 0u, 8u);
+    TEST_NUMBER_ERROR(kParseErrorNumberTooBig, "1e+50000", 0u, 8u);
 #endif
 
     // 9007199254740992 * 2^971 ("infinity")
@@ -693,7 +693,7 @@ static void TestParseNumberError() {
         "1.797693134862315907729305190789024733617976978942306572734300811577326758055009"
         "63132708477322407536021120113879871393357658789768814416622492847430639474124377"
         "76789342486548527630221960124609411945308295208500576883815068234246288147391311"
-        "0540827237163350510684586298239947245938479716304835356329624224137216e+308", 0, 315);
+        "0540827237163350510684586298239947245938479716304835356329624224137216e+308", 0u, 315u);
 
     // TODO:
     // These tests (currently) fail in normal-precision mode
@@ -715,7 +715,7 @@ static void TestParseNumberError() {
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
-            "00000000000000000000000000000000000000000000000000000000000000000000000000000000e+308", 0, 1125);
+            "00000000000000000000000000000000000000000000000000000000000000000000000000000000e+308", 0u, 1125u);
         // ...round up
         TEST_NUMBER_ERROR(kParseErrorNumberTooBig,
             "1.797693134862315807937289714053034150799341327100378269361737789804449682927647"
@@ -732,14 +732,14 @@ static void TestParseNumberError() {
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
             "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
-            "00000000000000000000000000000000000000000000000000000000000000000000000000000001e+308", 0, 1205);
+            "00000000000000000000000000000000000000000000000000000000000000000000000000000001e+308", 0u, 1205u);
     }
 
     TEST_NUMBER_ERROR(kParseErrorNumberTooBig,
         "10000000000000000000000000000000000000000000000000000000000000000000000000000000"
         "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
         "00000000000000000000000000000000000000000000000000000000000000000000000000000000"
-        "0000000000000000000000000000000000000000000000000000000000000000000001", 0, 310);
+        "0000000000000000000000000000000000000000000000000000000000000000000001", 0u, 310u);
 
 #undef TEST_NUMBER_ERROR
 }
@@ -931,21 +931,21 @@ TEST(Reader, ParseString_Error) {
     }
 
     // Invalid escape character in string.
-    TEST_STRING_ERROR(kParseErrorStringEscapeInvalid, "[\"\\a\"]", 2, 3);
+    TEST_STRING_ERROR(kParseErrorStringEscapeInvalid, "[\"\\a\"]", 2u, 3u);
 
     // Incorrect hex digit after \\u escape in string.
-    TEST_STRING_ERROR(kParseErrorStringUnicodeEscapeInvalidHex, "[\"\\uABCG\"]", 2, 7);
+    TEST_STRING_ERROR(kParseErrorStringUnicodeEscapeInvalidHex, "[\"\\uABCG\"]", 2u, 7u);
 
     // Quotation in \\u escape in string (Issue #288)
-    TEST_STRING_ERROR(kParseErrorStringUnicodeEscapeInvalidHex, "[\"\\uaaa\"]", 2, 7);
-    TEST_STRING_ERROR(kParseErrorStringUnicodeEscapeInvalidHex, "[\"\\uD800\\uFFF\"]", 2, 13);
+    TEST_STRING_ERROR(kParseErrorStringUnicodeEscapeInvalidHex, "[\"\\uaaa\"]", 2u, 7u);
+    TEST_STRING_ERROR(kParseErrorStringUnicodeEscapeInvalidHex, "[\"\\uD800\\uFFF\"]", 2u, 13u);
 
     // The surrogate pair in string is invalid.
-    TEST_STRING_ERROR(kParseErrorStringUnicodeSurrogateInvalid, "[\"\\uD800X\"]", 2, 8);
-    TEST_STRING_ERROR(kParseErrorStringUnicodeSurrogateInvalid, "[\"\\uD800\\uFFFF\"]", 2, 14);
+    TEST_STRING_ERROR(kParseErrorStringUnicodeSurrogateInvalid, "[\"\\uD800X\"]", 2u, 8u);
+    TEST_STRING_ERROR(kParseErrorStringUnicodeSurrogateInvalid, "[\"\\uD800\\uFFFF\"]", 2u, 14u);
 
     // Missing a closing quotation mark in string.
-    TEST_STRING_ERROR(kParseErrorStringMissQuotationMark, "[\"Test]", 7, 7);
+    TEST_STRING_ERROR(kParseErrorStringMissQuotationMark, "[\"Test]", 7u, 7u);
 
     // http://www.cl.cam.ac.uk/~mgk25/ucs/examples/UTF-8-test.txt
 
@@ -968,7 +968,7 @@ TEST(Reader, ParseString_Error) {
         char e[] = { '[', '\"', 0, ' ', '\"', ']', '\0' };
         for (unsigned c = 0xC0u; c <= 0xFFu; c++) {
             e[2] = static_cast<char>(c);
-            int streamPos;
+            unsigned streamPos;
             if (c <= 0xC1u)
                 streamPos = 3; // 0xC0 - 0xC1
             else if (c <= 0xDFu)
@@ -979,7 +979,7 @@ TEST(Reader, ParseString_Error) {
                 streamPos = 6; // 0xF0 - 0xF4
             else
                 streamPos = 3; // 0xF5 - 0xFF
-            TEST_STRING_ERROR(kParseErrorStringInvalidEncoding, e, 2, streamPos);
+            TEST_STRING_ERROR(kParseErrorStringInvalidEncoding, e, 2u, streamPos);
         }
     }
 
@@ -1062,7 +1062,7 @@ TEST(Reader, ParseArray) {
 TEST(Reader, ParseArray_Error) {
 #define TEST_ARRAY_ERROR(errorCode, str, errorOffset) \
     { \
-        int streamPos = errorOffset; \
+        unsigned streamPos = errorOffset; \
         char buffer[1001]; \
         strncpy(buffer, str, 1000); \
         InsituStringStream s(buffer); \
@@ -1075,13 +1075,13 @@ TEST(Reader, ParseArray_Error) {
     }
 
     // Missing a comma or ']' after an array element.
-    TEST_ARRAY_ERROR(kParseErrorArrayMissCommaOrSquareBracket, "[1", 2);
-    TEST_ARRAY_ERROR(kParseErrorArrayMissCommaOrSquareBracket, "[1}", 2);
-    TEST_ARRAY_ERROR(kParseErrorArrayMissCommaOrSquareBracket, "[1 2]", 3);
+    TEST_ARRAY_ERROR(kParseErrorArrayMissCommaOrSquareBracket, "[1", 2u);
+    TEST_ARRAY_ERROR(kParseErrorArrayMissCommaOrSquareBracket, "[1}", 2u);
+    TEST_ARRAY_ERROR(kParseErrorArrayMissCommaOrSquareBracket, "[1 2]", 3u);
 
     // Array cannot have a trailing comma (without kParseTrailingCommasFlag);
     // a value must follow a comma
-    TEST_ARRAY_ERROR(kParseErrorValueInvalid, "[1,]", 3);
+    TEST_ARRAY_ERROR(kParseErrorValueInvalid, "[1,]", 3u);
 
 #undef TEST_ARRAY_ERROR
 }
@@ -1230,7 +1230,7 @@ TEST(Reader, ParseInsituIterative_MultipleRoot) {
 
 #define TEST_ERROR(errorCode, str, errorOffset) \
     { \
-        int streamPos = errorOffset; \
+        unsigned streamPos = errorOffset; \
         char buffer[1001]; \
         strncpy(buffer, str, 1000); \
         InsituStringStream s(buffer); \
@@ -1244,48 +1244,48 @@ TEST(Reader, ParseInsituIterative_MultipleRoot) {
 
 TEST(Reader, ParseDocument_Error) {
     // The document is empty.
-    TEST_ERROR(kParseErrorDocumentEmpty, "", 0);
-    TEST_ERROR(kParseErrorDocumentEmpty, " ", 1);
-    TEST_ERROR(kParseErrorDocumentEmpty, " \n", 2);
+    TEST_ERROR(kParseErrorDocumentEmpty, "", 0u);
+    TEST_ERROR(kParseErrorDocumentEmpty, " ", 1u);
+    TEST_ERROR(kParseErrorDocumentEmpty, " \n", 2u);
 
     // The document root must not follow by other values.
-    TEST_ERROR(kParseErrorDocumentRootNotSingular, "[] 0", 3);
-    TEST_ERROR(kParseErrorDocumentRootNotSingular, "{} 0", 3);
-    TEST_ERROR(kParseErrorDocumentRootNotSingular, "null []", 5);
-    TEST_ERROR(kParseErrorDocumentRootNotSingular, "0 {}", 2);
+    TEST_ERROR(kParseErrorDocumentRootNotSingular, "[] 0", 3u);
+    TEST_ERROR(kParseErrorDocumentRootNotSingular, "{} 0", 3u);
+    TEST_ERROR(kParseErrorDocumentRootNotSingular, "null []", 5u);
+    TEST_ERROR(kParseErrorDocumentRootNotSingular, "0 {}", 2u);
 }
 
 TEST(Reader, ParseValue_Error) {
     // Invalid value.
-    TEST_ERROR(kParseErrorValueInvalid, "nulL", 3);
-    TEST_ERROR(kParseErrorValueInvalid, "truE", 3);
-    TEST_ERROR(kParseErrorValueInvalid, "falsE", 4);
-    TEST_ERROR(kParseErrorValueInvalid, "a]", 0);
-    TEST_ERROR(kParseErrorValueInvalid, ".1", 0);
+    TEST_ERROR(kParseErrorValueInvalid, "nulL", 3u);
+    TEST_ERROR(kParseErrorValueInvalid, "truE", 3u);
+    TEST_ERROR(kParseErrorValueInvalid, "falsE", 4u);
+    TEST_ERROR(kParseErrorValueInvalid, "a]", 0u);
+    TEST_ERROR(kParseErrorValueInvalid, ".1", 0u);
 }
 
 TEST(Reader, ParseObject_Error) {
     // Missing a name for object member.
-    TEST_ERROR(kParseErrorObjectMissName, "{1}", 1);
-    TEST_ERROR(kParseErrorObjectMissName, "{:1}", 1);
-    TEST_ERROR(kParseErrorObjectMissName, "{null:1}", 1);
-    TEST_ERROR(kParseErrorObjectMissName, "{true:1}", 1);
-    TEST_ERROR(kParseErrorObjectMissName, "{false:1}", 1);
-    TEST_ERROR(kParseErrorObjectMissName, "{1:1}", 1);
-    TEST_ERROR(kParseErrorObjectMissName, "{[]:1}", 1);
-    TEST_ERROR(kParseErrorObjectMissName, "{{}:1}", 1);
-    TEST_ERROR(kParseErrorObjectMissName, "{xyz:1}", 1);
+    TEST_ERROR(kParseErrorObjectMissName, "{1}", 1u);
+    TEST_ERROR(kParseErrorObjectMissName, "{:1}", 1u);
+    TEST_ERROR(kParseErrorObjectMissName, "{null:1}", 1u);
+    TEST_ERROR(kParseErrorObjectMissName, "{true:1}", 1u);
+    TEST_ERROR(kParseErrorObjectMissName, "{false:1}", 1u);
+    TEST_ERROR(kParseErrorObjectMissName, "{1:1}", 1u);
+    TEST_ERROR(kParseErrorObjectMissName, "{[]:1}", 1u);
+    TEST_ERROR(kParseErrorObjectMissName, "{{}:1}", 1u);
+    TEST_ERROR(kParseErrorObjectMissName, "{xyz:1}", 1u);
 
     // Missing a colon after a name of object member.
-    TEST_ERROR(kParseErrorObjectMissColon, "{\"a\" 1}", 5);
-    TEST_ERROR(kParseErrorObjectMissColon, "{\"a\",1}", 4);
+    TEST_ERROR(kParseErrorObjectMissColon, "{\"a\" 1}", 5u);
+    TEST_ERROR(kParseErrorObjectMissColon, "{\"a\",1}", 4u);
 
     // Must be a comma or '}' after an object member
-    TEST_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, "{\"a\":1]", 6);
+    TEST_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, "{\"a\":1]", 6u);
 
     // Object cannot have a trailing comma (without kParseTrailingCommasFlag);
     // an object member name must follow a comma
-    TEST_ERROR(kParseErrorObjectMissName, "{\"a\":1,}", 7);
+    TEST_ERROR(kParseErrorObjectMissName, "{\"a\":1,}", 7u);
 
     // This tests that MemoryStream is checking the length in Peek().
     {
@@ -1405,7 +1405,7 @@ TEST(Reader, Parse_IStreamWrapper_StringStream) {
 
 #define TESTERRORHANDLING(text, errorCode, offset)\
 {\
-    int streamPos = offset; \
+    unsigned streamPos = offset; \
     StringStream json(text); \
     BaseReaderHandler<> handler; \
     Reader reader; \
@@ -2153,7 +2153,7 @@ TEST(Reader, ParseNanAndInfinity) {
     }
 #define TEST_NAN_INF_ERROR(errorCode, str, errorOffset) \
     { \
-        int streamPos = errorOffset; \
+        unsigned streamPos = errorOffset; \
         char buffer[1001]; \
         strncpy(buffer, str, 1000); \
         InsituStringStream s(buffer); \
@@ -2174,14 +2174,14 @@ TEST(Reader, ParseNanAndInfinity) {
     TEST_NAN_INF("Infinity", inf);
     TEST_NAN_INF("-Inf", -inf);
     TEST_NAN_INF("-Infinity", -inf);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NInf", 1);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NaInf", 2);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "INan", 1);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "InNan", 2);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "nan", 1);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-nan", 1);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NAN", 1);
-    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-Infinty", 6);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NInf", 1u);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NaInf", 2u);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "INan", 1u);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "InNan", 2u);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "nan", 1u);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-nan", 1u);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NAN", 1u);
+    TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-Infinty", 6u);
 
 #undef TEST_NAN_INF_ERROR
 #undef TEST_NAN_INF

--- a/test/unittest/stringbuffertest.cpp
+++ b/test/unittest/stringbuffertest.cpp
@@ -41,11 +41,11 @@ TEST(StringBuffer, Put) {
 
 TEST(StringBuffer, PutN_Issue672) {
     GenericStringBuffer<UTF8<>, MemoryPoolAllocator<> > buffer;
-    EXPECT_EQ(0, buffer.GetSize());
-    EXPECT_EQ(0, buffer.GetLength());
+    EXPECT_EQ(0u, buffer.GetSize());
+    EXPECT_EQ(0u, buffer.GetLength());
     rapidjson::PutN(buffer, ' ', 1);
-    EXPECT_EQ(1, buffer.GetSize());
-    EXPECT_EQ(1, buffer.GetLength());
+    EXPECT_EQ(1u, buffer.GetSize());
+    EXPECT_EQ(1u, buffer.GetLength());
 }
 
 TEST(StringBuffer, Clear) {

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -26,11 +26,11 @@ using namespace rapidjson;
 TEST(Value, Size) {
     if (sizeof(SizeType) == 4) {
 #if RAPIDJSON_48BITPOINTER_OPTIMIZATION
-        EXPECT_EQ(16, sizeof(Value));
+        EXPECT_EQ(16u, sizeof(Value));
 #elif RAPIDJSON_64BIT
-        EXPECT_EQ(24, sizeof(Value));
+        EXPECT_EQ(24u, sizeof(Value));
 #else
-        EXPECT_EQ(16, sizeof(Value));
+        EXPECT_EQ(16u, sizeof(Value));
 #endif
     }
 }
@@ -1135,10 +1135,10 @@ TEST(Value, ArrayHelper) {
         a.PushBack(1, allocator);
 
         Value::Array a2(a); // copy constructor
-        EXPECT_EQ(1, a2.Size());
+        EXPECT_EQ(1u, a2.Size());
 
         Value::Array a3 = a;
-        EXPECT_EQ(1, a3.Size());
+        EXPECT_EQ(1u, a3.Size());
 
         Value::ConstArray y = static_cast<const Value&>(x).GetArray();
         (void)y;
@@ -1175,7 +1175,7 @@ TEST(Value, ArrayHelper) {
         y.PushBack(123, allocator);
         x.PushBack(y.GetArray(), allocator);    // Implicit constructor to convert Array to GenericValue
 
-        EXPECT_EQ(1, x.Size());
+        EXPECT_EQ(1u, x.Size());
         EXPECT_EQ(123, x[0][0].GetInt());
         EXPECT_TRUE(y.IsArray());
         EXPECT_TRUE(y.Empty());
@@ -1424,7 +1424,7 @@ static void TestObject(T& x, Allocator& allocator) {
     for (; itr != x.MemberEnd(); ++itr) {
         size_t i = static_cast<size_t>((itr - x.MemberBegin())) + 1;
         EXPECT_STREQ(itr->name.GetString(), keys[i]);
-        EXPECT_EQ(i, itr->value[0].GetInt());
+        EXPECT_EQ(static_cast<int>(i), itr->value[0].GetInt());
     }
 
     // Erase the last
@@ -1435,7 +1435,7 @@ static void TestObject(T& x, Allocator& allocator) {
     for (; itr != x.MemberEnd(); ++itr) {
         size_t i = static_cast<size_t>(itr - x.MemberBegin()) + 1;
         EXPECT_STREQ(itr->name.GetString(), keys[i]);
-        EXPECT_EQ(i, itr->value[0].GetInt());
+        EXPECT_EQ(static_cast<int>(i), itr->value[0].GetInt());
     }
 
     // Erase the middle
@@ -1447,7 +1447,7 @@ static void TestObject(T& x, Allocator& allocator) {
         size_t i = static_cast<size_t>(itr - x.MemberBegin());
         i += (i < 4) ? 1 : 2;
         EXPECT_STREQ(itr->name.GetString(), keys[i]);
-        EXPECT_EQ(i, itr->value[0].GetInt());
+        EXPECT_EQ(static_cast<int>(i), itr->value[0].GetInt());
     }
 
     // EraseMember(ConstMemberIterator, ConstMemberIterator)
@@ -1516,10 +1516,10 @@ TEST(Value, ObjectHelper) {
         o.AddMember("1", 1, allocator);
 
         Value::Object o2(o); // copy constructor
-        EXPECT_EQ(1, o2.MemberCount());
+        EXPECT_EQ(1u, o2.MemberCount());
 
         Value::Object o3 = o;
-        EXPECT_EQ(1, o3.MemberCount());
+        EXPECT_EQ(1u, o3.MemberCount());
 
         Value::ConstObject y = static_cast<const Value&>(x).GetObject();
         (void)y;


### PR DESCRIPTION
When upgrade to a new gtest, tests in rapidjson have some warnings about comparing between signed and unsigned values. This commit try to fix that.