### PR TITLE
Add a target to RapidJSONConfig.cmake.in

### DIFF
--- a/RapidJSONConfig.cmake.in
+++ b/RapidJSONConfig.cmake.in
@@ -13,3 +13,9 @@ get_filename_component(RapidJSON_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 set( RapidJSON_INCLUDE_DIR  "@RapidJSON_INCLUDE_DIR@" )
 set( RapidJSON_INCLUDE_DIRS  "@RapidJSON_INCLUDE_DIR@" )
 message(STATUS "RapidJSON found. Headers: ${RapidJSON_INCLUDE_DIRS}")
+
+if(NOT TARGET rapidjson)
+  add_library(rapidjson INTERFACE IMPORTED)
+  set_property(TARGET rapidjson PROPERTY
+    INTERFACE_INCLUDE_DIRECTORIES ${RapidJSON_INCLUDE_DIRS})
+endif()


### PR DESCRIPTION
This way, users can call target_link_libraries against the imported target, which is the recommended way of doing things.