### PR TITLE
faq: fix document insertion example

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -144,7 +144,7 @@
    
    Simple yet most efficient way to achieve that is to modify the `address` definition above to initialize it with allocator of the `person` document, then we just add the root member of the value:
    ~~~~~~~~~~cpp
-   Document address(person.GetAllocator());
+   Document address(&person.GetAllocator());
    ...
    person["person"].AddMember("address", address["address"], person.GetAllocator());
    ~~~~~~~~~~

--- a/doc/faq.zh-cn.md
+++ b/doc/faq.zh-cn.md
@@ -145,7 +145,7 @@
    一个简单有效的方法就是修改上述 `address` 变量的定义，让其使用 `person` 的 allocator 初始化，然后将其添加到根节点。
 
    ~~~~~~~~~~cpp
-   Documnet address(person.GetAllocator());
+   Documnet address(&person.GetAllocator());
    ...
    person["person"].AddMember("address", address["address"], person.GetAllocator());
    ~~~~~~~~~~


### PR DESCRIPTION
GenericDocument contructor requires a pointer to an Allocator, but GetAllocator() only
returns a reference.

Signed-off-by: Julien Courtat <julien.courtat@aqsacom.com>