### PR TITLE
Improve BasicIStreamWrapper performance by supplying a buffer (like FileReadStream)

### DIFF
--- a/include/rapidjson/istreamwrapper.h
+++ b/include/rapidjson/istreamwrapper.h
@@ -43,62 +43,82 @@ RAPIDJSON_NAMESPACE_BEGIN
 
     \tparam StreamType Class derived from \c std::basic_istream.
 */
-   
+
 template <typename StreamType>
 class BasicIStreamWrapper {
 public:
     typedef typename StreamType::char_type Ch;
-    BasicIStreamWrapper(StreamType& stream) : stream_(stream), count_(), peekBuffer_() {}
 
-    Ch Peek() const { 
-        typename StreamType::int_type c = stream_.peek();
-        return RAPIDJSON_LIKELY(c != StreamType::traits_type::eof()) ? static_cast<Ch>(c) : static_cast<Ch>('\0');
+    /*!
+        \param stream Stream to read from.
+        \param buffer user-supplied buffer.
+        \param bufferSize size of buffer in bytes. Must >=4 bytes.
+    */
+    BasicIStreamWrapper(StreamType& stream, Ch* buffer, size_t bufferSize)
+        : stream_(stream), buffer_(buffer), bufferSize_(bufferSize),
+        bufferLast_(0), current_(buffer_), readCount_(0), count_(0), eof_(false)
+    {
+        RAPIDJSON_ASSERT(bufferSize >= 4);
+        Read();
     }
 
-    Ch Take() { 
-        typename StreamType::int_type c = stream_.get();
-        if (RAPIDJSON_LIKELY(c != StreamType::traits_type::eof())) {
-            count_++;
-            return static_cast<Ch>(c);
-        }
-        else
-            return '\0';
+    /*!
+        \param stream Stream to read from. This uses unbuffered access, which can be extremely slow.
+    */
+    BasicIStreamWrapper(StreamType& stream)
+        : stream_(stream), buffer_(fallbackBuffer), bufferSize_(sizeof(fallbackBuffer)),
+        bufferLast_(0), current_(buffer_), readCount_(0), count_(0), eof_(false)
+    {
+        Read();
     }
 
-    // tellg() may return -1 when failed. So we count by ourself.
-    size_t Tell() const { return count_; }
+    Ch Peek() const { return *current_; }
+    Ch Take() { Ch c = *current_; Read(); return c; }
+    size_t Tell() const { return count_ + static_cast<size_t>(current_ - buffer_); }
 
-    Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
+    // Not implemented
     void Put(Ch) { RAPIDJSON_ASSERT(false); }
-    void Flush() { RAPIDJSON_ASSERT(false); }
+    void Flush() { RAPIDJSON_ASSERT(false); } 
+    Ch* PutBegin() { RAPIDJSON_ASSERT(false); return 0; }
     size_t PutEnd(Ch*) { RAPIDJSON_ASSERT(false); return 0; }
 
     // For encoding detection only.
     const Ch* Peek4() const {
-        RAPIDJSON_ASSERT(sizeof(Ch) == 1); // Only usable for byte stream.
-        int i;
-        bool hasError = false;
-        for (i = 0; i < 4; ++i) {
-            typename StreamType::int_type c = stream_.get();
-            if (c == StreamType::traits_type::eof()) {
-                hasError = true;
-                stream_.clear();
-                break;
-            }
-            peekBuffer_[i] = static_cast<Ch>(c);
-        }
-        for (--i; i >= 0; --i)
-            stream_.putback(peekBuffer_[i]);
-        return !hasError ? peekBuffer_ : 0;
+        return (current_ + 4 <= bufferLast_) ? current_ : 0;
     }
 
 private:
     BasicIStreamWrapper(const BasicIStreamWrapper&);
     BasicIStreamWrapper& operator=(const BasicIStreamWrapper&);
 
+    void Read() {
+        if (current_ < bufferLast_)
+            ++current_;
+        else if (!eof_) {
+            count_ += readCount_;
+            stream_.read(buffer_, (std::streamsize)bufferSize_);
+            readCount_ = (size_t)stream_.gcount();
+            bufferLast_ = buffer_ + readCount_ - 1;
+            current_ = buffer_;
+
+            if (readCount_ < bufferSize_) {
+                buffer_[readCount_] = '\0';
+                ++bufferLast_;
+                eof_ = true;
+            }
+        }
+    }
+
     StreamType& stream_;
-    size_t count_;  //!< Number of characters read. Note:
-    mutable Ch peekBuffer_[4];
+
+    Ch *buffer_;
+    size_t bufferSize_;
+    Ch *bufferLast_;
+    Ch *current_;
+    size_t readCount_;
+    size_t count_;  //!< Number of characters read
+    bool eof_;
+    Ch fallbackBuffer[5];
 };
 
 typedef BasicIStreamWrapper<std::istream> IStreamWrapper;

--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -23,6 +23,8 @@
 #include "rapidjson/filereadstream.h"
 #include "rapidjson/encodedstream.h"
 #include "rapidjson/memorystream.h"
+#include "rapidjson/istreamwrapper.h"
+#include <fstream>
 
 #ifdef RAPIDJSON_SSE2
 #define SIMD_SUFFIX(name) name##_SSE2
@@ -448,6 +450,16 @@ TEST_F(RapidJson, FileReadStream) {
         while (s.Take() != '\0')
             ;
         fclose(fp);
+    }
+}
+
+TEST_F(RapidJson, BasicIStreamWrapper) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        std::ifstream iss (filename_, std::ios::in | std::ios::binary);
+        char buffer[65536];
+        BasicIStreamWrapper<std::ifstream> is(iss, buffer, sizeof(buffer));
+        while (is.Take() != '\0')
+            ;
     }
 }
 


### PR DESCRIPTION
Significantly improves performance over unbuffered access to the underlying istream. (factor 10)
With these changes, the performance is essentially the same as for FileReadStream.