### PR TITLE
silence clang-7 self-assign-overloaded warning

### DIFF
--- a/test/unittest/pointertest.cpp
+++ b/test/unittest/pointertest.cpp
@@ -503,7 +503,7 @@ TEST(Pointer, Assignment) {
         EXPECT_STREQ("0", q.GetTokens()[1].name);
         EXPECT_EQ(0u, q.GetTokens()[1].index);
         EXPECT_NE(&p.GetAllocator(), &q.GetAllocator());
-        q = static_cast<Pointer>(q);
+        q = static_cast<const Pointer &>(q);
         EXPECT_TRUE(q.IsValid());
         EXPECT_EQ(2u, q.GetTokenCount());
         EXPECT_EQ(3u, q.GetTokens()[0].length);

--- a/test/unittest/pointertest.cpp
+++ b/test/unittest/pointertest.cpp
@@ -503,7 +503,7 @@ TEST(Pointer, Assignment) {
         EXPECT_STREQ("0", q.GetTokens()[1].name);
         EXPECT_EQ(0u, q.GetTokens()[1].index);
         EXPECT_NE(&p.GetAllocator(), &q.GetAllocator());
-        q = q;
+        q = static_cast<Pointer>(q);
         EXPECT_TRUE(q.IsValid());
         EXPECT_EQ(2u, q.GetTokenCount());
         EXPECT_EQ(3u, q.GetTokens()[0].length);


### PR DESCRIPTION
Without this change clang-7 won't compile `poiontertest.cpp` with the following error:
```
../test/unittest/pointertest.cpp:506:11: error: explicitly assigning value of variable of type 'rapidjson::Pointer' (aka 'GenericPointer<GenericValue<UTF8<> > >') to itself [-Werror,-Wself-assign-overloaded]
        q = q;
        ~ ^ ~
```
See http://releases.llvm.org/7.0.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics.

I thought it is better to use casting instead of silencing the error throughout the codebase