### PR TITLE
Fix memory leak when an exception is thrown in GetRemoteDocument

### DIFF
--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -2089,7 +2089,7 @@ TEST(SchemaException, Ref_exception_issue818) {
 
     Document x, y;
     x.Parse("{\"properties\":{\"country\":{\"$ref\":\"y.json#/definitions/country\"},\"language\":{\"$ref\":\"z.json#/definitions/language\"}},\"type\":\"object\"}");
-    y.Parse("{\"definitions\":{\"country\":{\"enum\":\[\"UK\"]}}}");
+    y.Parse("{\"definitions\":{\"country\":{\"enum\":[\"UK\"]}}}");
 
     SchemaDocument sy(y, "y.json", 6, &provider);
     collection[0] = &sy;


### PR DESCRIPTION
To address #818, any resources must be freed when an exception is thrown in `GetRemoteDocument`.

Any exception thrown in `GetRemoteDocument` will stop the process of resolving the schema, resources already allocated will be freed properly and the `GenericSchemaDocument` will not be constructed.

I'm not sure if this part is acceptable in the RapidJSON code base, since I've not seen any exception support like it anywhere else in the files. If it's not, I think the `GetRemoteDocument` should be made `noexcept`.