### PR TITLE
Track (sub-)schema(s) validity and provide SchemaDocument::IsValid().

### DIFF
--- a/include/rapidjson/internal/regex.h
+++ b/include/rapidjson/internal/regex.h
@@ -392,8 +392,7 @@ private:
                 }
                 return false;
 
-            default: 
-                RAPIDJSON_ASSERT(op == kOneOrMore);
+            case kOneOrMore:
                 if (operandStack.GetSize() >= sizeof(Frag)) {
                     Frag e = *operandStack.template Pop<Frag>(1);
                     SizeType s = NewState(kRegexInvalidState, e.start, 0);
@@ -401,6 +400,10 @@ private:
                     *operandStack.template Push<Frag>() = Frag(e.start, s, e.minIndex);
                     return true;
                 }
+                return false;
+
+            default: 
+                // syntax error (e.g. unclosed kLeftParenthesis)
                 return false;
         }
     }

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -429,9 +429,9 @@ public:
         hasRequired_(),
         hasSchemaDependencies_(),
         additionalItemsSchema_(),
+        itemsSchema_(),
         itemsList_(),
-        itemsTuple_(),
-        itemsTupleCount_(),
+        itemsListCount_(),
         minItems_(),
         maxItems_(SizeType(~0)),
         additionalItems_(true),
@@ -636,14 +636,14 @@ public:
         // Array
         if (const ValueType* v = GetMember(value, GetItemsString())) {
             PointerType q = p.Append(GetItemsString(), allocator_);
-            if (v->IsArray()) { // Tuple validation
-                itemsTuple_ = static_cast<const Schema**>(allocator_->Malloc(sizeof(const Schema*) * v->Size()));
+            if (v->IsArray()) { // List validation
+                itemsList_ = static_cast<const Schema**>(allocator_->Malloc(sizeof(const Schema*) * v->Size()));
                 SizeType index = 0;
                 for (ConstValueIterator itr = v->Begin(); itr != v->End(); ++itr, index++)
-                    valid_ &= schemaDocument->CreateSchema(&itemsTuple_[itemsTupleCount_++], q.Append(index, allocator_), *itr, document);
+                    valid_ &= schemaDocument->CreateSchema(&itemsList_[itemsListCount_++], q.Append(index, allocator_), *itr, document);
             }
             else
-                valid_ &= schemaDocument->CreateSchema(&itemsList_, q, *v, document);
+                valid_ &= schemaDocument->CreateSchema(&itemsSchema_, q, *v, document);
         }
 
         AssignIfExist(minItems_, value, GetMinItemsString());
@@ -711,7 +711,7 @@ public:
                 patternProperties_[i].~PatternProperty();
             AllocatorType::Free(patternProperties_);
         }
-        AllocatorType::Free(itemsTuple_);
+        AllocatorType::Free(itemsList_);
 #if RAPIDJSON_SCHEMA_HAS_REGEX
         if (pattern_) {
             pattern_->~RegexType();
@@ -737,11 +737,11 @@ public:
             if (uniqueItems_)
                 context.valueUniqueness = true;
 
-            if (itemsList_)
-                context.valueSchema = itemsList_;
-            else if (itemsTuple_) {
-                if (context.arrayElementIndex < itemsTupleCount_)
-                    context.valueSchema = itemsTuple_[context.arrayElementIndex];
+            if (itemsSchema_)
+                context.valueSchema = itemsSchema_;
+            else if (itemsList_) {
+                if (context.arrayElementIndex < itemsListCount_)
+                    context.valueSchema = itemsList_[context.arrayElementIndex];
                 else if (additionalItemsSchema_)
                     context.valueSchema = additionalItemsSchema_;
                 else if (additionalItems_)
@@ -1489,9 +1489,9 @@ private:
     bool hasSchemaDependencies_;
 
     const SchemaType* additionalItemsSchema_;
-    const SchemaType* itemsList_;
-    const SchemaType** itemsTuple_;
-    SizeType itemsTupleCount_;
+    const SchemaType* itemsSchema_;
+    const SchemaType** itemsList_;
+    SizeType itemsListCount_;
     SizeType minItems_;
     SizeType maxItems_;
     bool additionalItems_;

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -598,16 +598,16 @@ public:
             hasDependencies_ = true;
             for (ConstMemberIterator itr = dependencies->MemberBegin(); itr != dependencies->MemberEnd(); ++itr) {
                 SizeType sourceIndex;
-                bool found = FindPropertyIndex(itr->name, &sourceIndex);
-                RAPIDJSON_ASSERT(found); (void)found;
+                bool source_found = FindPropertyIndex(itr->name, &sourceIndex);
+                RAPIDJSON_ASSERT(source_found); (void)source_found;
                 if (itr->value.IsArray()) {
                     properties_[sourceIndex].dependencies = static_cast<bool*>(allocator_->Malloc(sizeof(bool) * propertyCount_));
                     std::memset(properties_[sourceIndex].dependencies, 0, sizeof(bool)* propertyCount_);
                     for (ConstValueIterator targetItr = itr->value.Begin(); targetItr != itr->value.End(); ++targetItr) {
                         SizeType targetIndex;
                         if (targetItr->IsString()) {
-                            bool found = FindPropertyIndex(*targetItr, &targetIndex);
-                            RAPIDJSON_ASSERT(found); (void)found;
+                            bool target_found = FindPropertyIndex(*targetItr, &targetIndex);
+                            RAPIDJSON_ASSERT(target_found); (void)target_found;
                             properties_[sourceIndex].dependencies[targetIndex] = true;
                         }
                     }

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -2265,12 +2265,14 @@ TEST(Schema, InvalidParsing) {
     d_bad_multipleOf.Parse("{ \"type\": \"object\", \"multipleOf\": 0 }");
     EXPECT_FALSE(d_bad_multipleOf.HasParseError());
     SchemaDocument sd_bad_multipleOf(d_bad_multipleOf);
+    EXPECT_FALSE(sd_bad_multipleOf.IsValid());
 
-    // "defaultValue" is a string
-    Document d_bad_defaultValue;
-    d_bad_defaultValue.Parse("{ \"type\": \"object\", \"defaultValue\": false }");
-    EXPECT_FALSE(d_bad_defaultValue.HasParseError());
-    SchemaDocument sd_bad_defaultValue(d_bad_defaultValue);
+    // "default" is a string
+    Document d_bad_default;
+    d_bad_default.Parse("{ \"type\": \"object\", \"default\": false }");
+    EXPECT_FALSE(d_bad_default.HasParseError());
+    SchemaDocument sd_bad_default(d_bad_default);
+    EXPECT_FALSE(sd_bad_default.IsValid());
 }
 
 #if defined(_MSC_VER) || defined(__clang__)

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -2067,6 +2067,212 @@ TEST(SchemaValidator, Ref_remote_issue1210) {
     VALIDATE(sx, "{\"country\":\"US\"}", true);
 }
 
+TEST(Schema, InvalidParsing) {
+    // "type" is a string
+    Document d_bad_type;
+    d_bad_type.Parse("{ \"type\": true }");
+    EXPECT_FALSE(d_bad_type.HasParseError());
+    SchemaDocument sd_bad_type(d_bad_type);
+    EXPECT_FALSE(sd_bad_type.IsValid());
+
+    // "enum" is a non empty array
+    Document d_bad_enum, d_bad_enum_empty;
+    d_bad_enum.Parse("{ \"enum\" : \"not a string\" }");
+    EXPECT_FALSE(d_bad_enum.HasParseError());
+    SchemaDocument sd_bad_enum(d_bad_enum);
+    EXPECT_FALSE(sd_bad_enum.IsValid());
+    d_bad_enum_empty.Parse("{ \"enum\" : [] }");
+    EXPECT_FALSE(d_bad_enum_empty.HasParseError());
+    SchemaDocument sd_bad_enum_empty(d_bad_enum_empty);
+    EXPECT_FALSE(sd_bad_enum_empty.IsValid());
+
+    // "allOf" is a non empty array
+    Document d_bad_allOf, d_bad_allOf_empty;
+    d_bad_allOf.Parse("{ \"allOf\": { \"type\": \"string\" } }");
+    EXPECT_FALSE(d_bad_allOf.HasParseError());
+    SchemaDocument sd_bad_allOf(d_bad_allOf);
+    EXPECT_FALSE(sd_bad_allOf.IsValid());
+    d_bad_allOf_empty.Parse("{ \"allOf\" : [] }");
+    EXPECT_FALSE(d_bad_allOf_empty.HasParseError());
+    SchemaDocument sd_bad_allOf_empty(d_bad_allOf_empty);
+    EXPECT_FALSE(sd_bad_allOf_empty.IsValid());
+
+    // "anyOf" is a non empty array
+    Document d_bad_anyOf, d_bad_anyOf_empty;
+    d_bad_anyOf.Parse("{ \"anyOf\": { \"type\": \"string\" } }");
+    EXPECT_FALSE(d_bad_anyOf.HasParseError());
+    SchemaDocument sd_bad_anyOf(d_bad_anyOf);
+    EXPECT_FALSE(sd_bad_anyOf.IsValid());
+    d_bad_anyOf_empty.Parse("{ \"anyOf\" : [] }");
+    EXPECT_FALSE(d_bad_anyOf_empty.HasParseError());
+    SchemaDocument sd_bad_anyOf_empty(d_bad_anyOf_empty);
+    EXPECT_FALSE(sd_bad_anyOf_empty.IsValid());
+
+    // "oneOf" is a non empty array
+    Document d_bad_oneOf, d_bad_oneOf_empty;
+    d_bad_oneOf.Parse("{ \"oneOf\": { \"type\": \"string\" } }");
+    EXPECT_FALSE(d_bad_oneOf.HasParseError());
+    SchemaDocument sd_bad_oneOf(d_bad_oneOf);
+    EXPECT_FALSE(sd_bad_oneOf.IsValid());
+    d_bad_oneOf_empty.Parse("{ \"oneOf\" : [] }");
+    EXPECT_FALSE(d_bad_oneOf_empty.HasParseError());
+    SchemaDocument sd_bad_oneOf_empty(d_bad_oneOf_empty);
+    EXPECT_FALSE(sd_bad_oneOf_empty.IsValid());
+
+    // "not" is an object/schema
+    Document d_bad_not;
+    d_bad_not.Parse("{\"not\": [ { \"type\": \"string\" } ] }");
+    EXPECT_FALSE(d_bad_not.HasParseError());
+    SchemaDocument sd_bad_not(d_bad_not);
+    EXPECT_FALSE(sd_bad_not.IsValid());
+
+    // "properties" is an object/schema
+    Document d_bad_properties;
+    d_bad_properties.Parse("{ \"type\": \"object\", \"properties\": [ \"a\", \"b\" ] }");
+    EXPECT_FALSE(d_bad_properties.HasParseError());
+    SchemaDocument sd_bad_properties(d_bad_properties);
+    EXPECT_FALSE(sd_bad_properties.IsValid());
+
+    // "required" is an array of strings
+    Document d_bad_required, d_bad_required_string;
+    d_bad_required.Parse("{ \"type\": \"object\", \"properties\": { \"a\": { \"type\": \"string\" }, \"b\": { \"type\": \"string\" } }, \"required\": \"a\" }");
+    EXPECT_FALSE(d_bad_required.HasParseError());
+    SchemaDocument sd_bad_required(d_bad_required);
+    EXPECT_FALSE(sd_bad_required.IsValid());
+    d_bad_required_string.Parse("{ \"type\": \"object\", \"properties\": { \"a\": { \"type\": \"string\" }, \"b\": { \"type\": \"string\" } }, \"required\": [ \"a\", 10 ] }");
+    EXPECT_FALSE(d_bad_required_string.HasParseError());
+    SchemaDocument sd_bad_required_string(d_bad_required_string);
+    EXPECT_FALSE(sd_bad_required_string.IsValid());
+
+    // "dependencies" is an object whose values are arrays of strings, or an object/schema
+    Document d_bad_dependencies, d_bad_dependencies_array, d_bad_dependencies_array_string;
+    d_bad_dependencies.Parse("{ \"type\": \"integer\", \"dependencies\": 69 }");
+    EXPECT_FALSE(d_bad_dependencies.HasParseError());
+    SchemaDocument sd_bad_dependencies(d_bad_dependencies);
+    EXPECT_FALSE(sd_bad_dependencies.IsValid());
+    d_bad_dependencies_array.Parse("{ \"type\": \"integer\", \"dependencies\": { \"a\": 69 } }");
+    EXPECT_FALSE(d_bad_dependencies_array.HasParseError());
+    SchemaDocument sd_bad_dependencies_array(d_bad_dependencies_array);
+    EXPECT_FALSE(sd_bad_dependencies_array.IsValid());
+    d_bad_dependencies_array_string.Parse("{ \"type\": \"integer\", \"dependencies\": { \"a\": [ 69 ] } }");
+    EXPECT_FALSE(d_bad_dependencies_array_string.HasParseError());
+    SchemaDocument sd_bad_dependencies_array_string(d_bad_dependencies_array_string);
+    EXPECT_FALSE(sd_bad_dependencies_array_string.IsValid());
+
+    // "patternProperties" is an object whose keys are valid regexes
+    Document d_bad_patternProperties, d_bad_patternProperties_pattern;
+    d_bad_patternProperties.Parse("{ \"type\": \"object\", \"patternProperties\": \"not an object\" }");
+    EXPECT_FALSE(d_bad_patternProperties.HasParseError());
+    SchemaDocument sd_bad_patternProperties(d_bad_patternProperties);
+    EXPECT_FALSE(sd_bad_patternProperties.IsValid());
+    d_bad_patternProperties_pattern.Parse("{ \"type\": \"object\", \"patternProperties\": { \"(unclosed\": { \"type\": \"string\" } } }");
+    EXPECT_FALSE(d_bad_patternProperties_pattern.HasParseError());
+    SchemaDocument sd_bad_patternProperties_pattern(d_bad_patternProperties_pattern);
+    EXPECT_FALSE(sd_bad_patternProperties_pattern.IsValid());
+
+    // "additionalProperties" is a boolean or an object/schema
+    Document d_bad_additionalProperties;
+    d_bad_additionalProperties.Parse("{ \"type\": \"object\", \"additionalProperties\": \"not a bool or an object\" }");
+    EXPECT_FALSE(d_bad_additionalProperties.HasParseError());
+    SchemaDocument sd_bad_additionalProperties(d_bad_additionalProperties);
+    EXPECT_FALSE(sd_bad_additionalProperties.IsValid());
+
+    // "min/maxProperties" are positive or nul integers
+    Document d_bad_minProperties, d_bad_maxProperties;
+    d_bad_minProperties.Parse("{ \"type\": \"object\", \"minProperties\": -1 }");
+    EXPECT_FALSE(d_bad_minProperties.HasParseError());
+    SchemaDocument sd_bad_minProperties(d_bad_minProperties);
+    EXPECT_FALSE(sd_bad_minProperties.IsValid());
+    d_bad_maxProperties.Parse("{ \"type\": \"object\", \"maxProperties\": false }");
+    EXPECT_FALSE(d_bad_maxProperties.HasParseError());
+    SchemaDocument sd_bad_maxProperties(d_bad_maxProperties);
+    EXPECT_FALSE(sd_bad_maxProperties.IsValid());
+
+    // "items" is an array or an object/schema
+    Document d_bad_items;
+    d_bad_items.Parse("{ \"type\": \"object\", \"items\": \"not an array or an object\" }");
+    EXPECT_FALSE(d_bad_items.HasParseError());
+    SchemaDocument sd_bad_items(d_bad_items);
+    EXPECT_FALSE(sd_bad_items.IsValid());
+
+    // "min/maxItems" are positive or nul integers
+    Document d_bad_minItems, d_bad_maxItems;
+    d_bad_minItems.Parse("{ \"type\": \"object\", \"minItems\": -1 }");
+    EXPECT_FALSE(d_bad_minItems.HasParseError());
+    SchemaDocument sd_bad_minItems(d_bad_minItems);
+    EXPECT_FALSE(sd_bad_minItems.IsValid());
+    d_bad_maxItems.Parse("{ \"type\": \"object\", \"maxItems\": false }");
+    EXPECT_FALSE(d_bad_maxItems.HasParseError());
+    SchemaDocument sd_bad_maxItems(d_bad_maxItems);
+    EXPECT_FALSE(sd_bad_maxItems.IsValid());
+
+    // "additionalItems" is a boolean or an object/schema
+    Document d_bad_additionalItems;
+    d_bad_additionalItems.Parse("{ \"type\": \"object\", \"additionalItems\": \"not a bool or an object\" }");
+    EXPECT_FALSE(d_bad_additionalItems.HasParseError());
+    SchemaDocument sd_bad_additionalItems(d_bad_additionalItems);
+    EXPECT_FALSE(sd_bad_additionalItems.IsValid());
+
+    // "uniqueItems" is a bool
+    Document d_bad_uniqueItems;
+    d_bad_uniqueItems.Parse("{ \"uniqueItems\": \"not a bool\" }");
+    EXPECT_FALSE(d_bad_uniqueItems.HasParseError());
+    SchemaDocument sd_bad_uniqueItems(d_bad_uniqueItems);
+    EXPECT_FALSE(sd_bad_uniqueItems.IsValid());
+
+    // "min/maxLength" are positive or nul integers
+    Document d_bad_minLength, d_bad_maxLength;
+    d_bad_minLength.Parse("{ \"type\": \"object\", \"minLength\": -1 }");
+    EXPECT_FALSE(d_bad_minLength.HasParseError());
+    SchemaDocument sd_bad_minLength(d_bad_minLength);
+    EXPECT_FALSE(sd_bad_minLength.IsValid());
+    d_bad_maxLength.Parse("{ \"type\": \"object\", \"maxLength\": false }");
+    EXPECT_FALSE(d_bad_maxLength.HasParseError());
+    SchemaDocument sd_bad_maxLength(d_bad_maxLength);
+    EXPECT_FALSE(sd_bad_maxLength.IsValid());
+
+    // "pattern" is a regex
+    Document d_bad_pattern;
+    d_bad_pattern.Parse("{ \"pattern\": \"(unclosed\" }");
+    EXPECT_FALSE(d_bad_pattern.HasParseError());
+    SchemaDocument sd_bad_pattern(d_bad_pattern);
+    EXPECT_FALSE(sd_bad_pattern.IsValid());
+
+    // "minimum/maximum" are numbers
+    Document d_bad_minimum, d_bad_maximum;
+    d_bad_minimum.Parse("{ \"type\": \"object\", \"minimum\": \"not a number\" }");
+    EXPECT_FALSE(d_bad_minimum.HasParseError());
+    SchemaDocument sd_bad_minimum(d_bad_minimum);
+    EXPECT_FALSE(sd_bad_minimum.IsValid());
+    d_bad_maximum.Parse("{ \"type\": \"object\", \"maximum\": false }");
+    EXPECT_FALSE(d_bad_maximum.HasParseError());
+    SchemaDocument sd_bad_maximum(d_bad_maximum);
+    EXPECT_FALSE(sd_bad_maximum.IsValid());
+
+    // "exclusiveMinimum/exclusiveMaximum" are booleans
+    Document d_bad_exclusiveMinimum, d_bad_exclusiveMaximum;
+    d_bad_exclusiveMinimum.Parse("{ \"type\": \"object\", \"exclusiveMinimum\": 1 }");
+    EXPECT_FALSE(d_bad_exclusiveMinimum.HasParseError());
+    SchemaDocument sd_bad_exclusiveMinimum(d_bad_exclusiveMinimum);
+    EXPECT_FALSE(sd_bad_exclusiveMinimum.IsValid());
+    d_bad_exclusiveMaximum.Parse("{ \"type\": \"object\", \"exclusiveMaximum\": \"not a bool\" }");
+    EXPECT_FALSE(d_bad_exclusiveMaximum.HasParseError());
+    SchemaDocument sd_bad_exclusiveMaximum(d_bad_exclusiveMaximum);
+    EXPECT_FALSE(sd_bad_exclusiveMaximum.IsValid());
+
+    // "multipleOf" is a stricly positive number
+    Document d_bad_multipleOf;
+    d_bad_multipleOf.Parse("{ \"type\": \"object\", \"multipleOf\": 0 }");
+    EXPECT_FALSE(d_bad_multipleOf.HasParseError());
+    SchemaDocument sd_bad_multipleOf(d_bad_multipleOf);
+
+    // "defaultValue" is a string
+    Document d_bad_defaultValue;
+    d_bad_defaultValue.Parse("{ \"type\": \"object\", \"defaultValue\": false }");
+    EXPECT_FALSE(d_bad_defaultValue.HasParseError());
+    SchemaDocument sd_bad_defaultValue(d_bad_defaultValue);
+}
+
 #if defined(_MSC_VER) || defined(__clang__)
 RAPIDJSON_DIAG_POP
 #endif


### PR DESCRIPTION
Set valid_ = false wherever the schema is malformed (e.g. unexpected type) or incomplete (dangling "$refs"), and return it in SchemaDociment::IsValid().