### PR TITLE
GenericRegex: don't throw/abort on syntax error (unclosed parenthesis).

### DIFF
--- a/include/rapidjson/internal/regex.h
+++ b/include/rapidjson/internal/regex.h
@@ -395,8 +395,7 @@ private:
                 }
                 return false;
 
-            default: 
-                RAPIDJSON_ASSERT(op == kOneOrMore);
+            case kOneOrMore:
                 if (operandStack.GetSize() >= sizeof(Frag)) {
                     Frag e = *operandStack.template Pop<Frag>(1);
                     SizeType s = NewState(kRegexInvalidState, e.start, 0);
@@ -404,6 +403,10 @@ private:
                     *operandStack.template Push<Frag>() = Frag(e.start, s, e.minIndex);
                     return true;
                 }
+                return false;
+
+            default: 
+                // syntax error (e.g. unclosed kLeftParenthesis)
                 return false;
         }
     }

--- a/test/unittest/regextest.cpp
+++ b/test/unittest/regextest.cpp
@@ -595,6 +595,7 @@ TEST(Regex, Invalid) {
     TEST_INVALID("");
     TEST_INVALID("a|");
     TEST_INVALID("()");
+    TEST_INVALID("(");
     TEST_INVALID(")");
     TEST_INVALID("(a))");
     TEST_INVALID("(a|)");


### PR DESCRIPTION
An invalid regex shouldn't kill the process, IsValid() can be checked.