### PR TITLE
Optimize FileReadStream and BasicIStreamWrapper.

### DIFF
--- a/include/rapidjson/filereadstream.h
+++ b/include/rapidjson/filereadstream.h
@@ -17,7 +17,6 @@
 
 #include "stream.h"
 #include <cstdio>
-#include <cstring>
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH
@@ -39,39 +38,18 @@ public:
     //! Constructor.
     /*!
         \param fp File pointer opened for read.
-    */
-    FileReadStream(std::FILE* fp) : fp_(fp), buffer_(peekBuffer_), size_(sizeof(peekBuffer_) / sizeof(Ch)), pos_(), len_(), count_()
-    {
-        RAPIDJSON_ASSERT(fp_ != 0);
-    }
-
-    //! Constructor.
-    /*!
-        \param fp File pointer opened for read.
         \param buffer user-supplied buffer.
         \param bufferSize size of buffer in bytes. Must >=4 bytes.
     */
-    FileReadStream(std::FILE* fp, Ch *buffer, size_t size) : fp_(fp), buffer_(buffer), size_(size), pos_(), len_(), count_() {
-        RAPIDJSON_ASSERT(fp_ != 0 && buffer_ != 0 && size_ > 0);
-        if (RAPIDJSON_UNLIKELY(size_ < sizeof(peekBuffer_) / sizeof(Ch))) {
-            size_ = sizeof(peekBuffer_) / sizeof(Ch);
-            buffer_ = peekBuffer_;
-        }
+    FileReadStream(std::FILE* fp, char* buffer, size_t bufferSize) : fp_(fp), buffer_(buffer), bufferSize_(bufferSize), bufferLast_(0), current_(buffer_), readCount_(0), count_(0), eof_(false) { 
+        RAPIDJSON_ASSERT(fp_ != 0);
+        RAPIDJSON_ASSERT(bufferSize >= 4);
+        Read();
     }
 
-    Ch Peek() const {
-        if (RAPIDJSON_UNLIKELY(pos_ == len_) && !Read())
-            return static_cast<Ch>('\0');
-        return buffer_[pos_];
-    }
-
-    Ch Take() {
-        if (RAPIDJSON_UNLIKELY(pos_ == len_) && !Read())
-            return static_cast<Ch>('\0');
-        return buffer_[pos_++];
-    }
-
-    size_t Tell() const { return count_ + pos_; }
+    Ch Peek() const { return *current_; }
+    Ch Take() { Ch c = *current_; Read(); return c; }
+    size_t Tell() const { return count_ + static_cast<size_t>(current_ - buffer_); }
 
     // Not implemented
     void Put(Ch) { RAPIDJSON_ASSERT(false); }
@@ -81,36 +59,35 @@ public:
 
     // For encoding detection only.
     const Ch* Peek4() const {
-        if (len_ - pos_ < 4) {
-            if (pos_) {
-                len_ -= pos_;
-                std::memmove(buffer_, buffer_ + pos_, len_);
-                count_ += pos_;
-                pos_ = 0;
-            }
-            len_ += std::fread(buffer_ + len_, sizeof(Ch), size_ - len_, fp_);
-            if (len_ < 4)
-                return 0;
-        }
-        return &buffer_[pos_];
+        return (current_ + 4 <= bufferLast_) ? current_ : 0;
     }
 
 private:
-    FileReadStream();
-    FileReadStream(const FileReadStream&);
-    FileReadStream& operator=(const FileReadStream&);
+    void Read() {
+        if (current_ < bufferLast_)
+            ++current_;
+        else if (!eof_) {
+            count_ += readCount_;
+            readCount_ = std::fread(buffer_, 1, bufferSize_, fp_);
+            bufferLast_ = buffer_ + readCount_ - 1;
+            current_ = buffer_;
 
-    size_t Read() const {
-        count_ += pos_;
-        pos_ = 0;
-        len_ = std::fread(buffer_, sizeof(Ch), size_, fp_);
-        return len_;
+            if (readCount_ < bufferSize_) {
+                buffer_[readCount_] = '\0';
+                ++bufferLast_;
+                eof_ = true;
+            }
+        }
     }
 
     std::FILE* fp_;
-    Ch peekBuffer_[4], *buffer_;
-    size_t size_;
-    mutable size_t pos_, len_, count_;
+    Ch *buffer_;
+    size_t bufferSize_;
+    Ch *bufferLast_;
+    Ch *current_;
+    size_t readCount_;
+    size_t count_;  //!< Number of characters read
+    bool eof_;
 };
 
 RAPIDJSON_NAMESPACE_END

--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -489,7 +489,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_FileReadStream_Unbuffered
 
 TEST_F(RapidJson, IStreamWrapper) {
     for (size_t i = 0; i < kTrialCount; i++) {
-        std::ifstream is(filename_);
+        std::ifstream is(filename_, std::ios::in | std::ios::binary);
         char buffer[65536];
         IStreamWrapper isw(is, buffer, sizeof(buffer));
         while (isw.Take() != '\0')
@@ -500,7 +500,7 @@ TEST_F(RapidJson, IStreamWrapper) {
 
 TEST_F(RapidJson, IStreamWrapper_Unbuffered) {
     for (size_t i = 0; i < kTrialCount; i++) {
-        std::ifstream is(filename_);
+        std::ifstream is(filename_, std::ios::in | std::ios::binary);
         IStreamWrapper isw(is);
         while (isw.Take() != '\0')
             ;
@@ -513,7 +513,7 @@ TEST_F(RapidJson, IStreamWrapper_Setbuffered) {
         std::ifstream is;
         char buffer[65536];
         is.rdbuf()->pubsetbuf(buffer, sizeof(buffer));
-        is.open(filename_);
+        is.open(filename_, std::ios::in | std::ios::binary);
         IStreamWrapper isw(is);
         while (isw.Take() != '\0')
             ;
@@ -523,7 +523,7 @@ TEST_F(RapidJson, IStreamWrapper_Setbuffered) {
 
 TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_IStreamWrapper)) {
     for (size_t i = 0; i < kTrialCount; i++) {
-        std::ifstream is(filename_);
+        std::ifstream is(filename_, std::ios::in | std::ios::binary);
         char buffer[65536];
         IStreamWrapper isw(is, buffer, sizeof(buffer));
         BaseReaderHandler<> h;
@@ -535,7 +535,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_IStreamWrapper)) {
 
 TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_IStreamWrapper_Unbuffered)) {
     for (size_t i = 0; i < kTrialCount; i++) {
-        std::ifstream is(filename_);
+        std::ifstream is(filename_, std::ios::in | std::ios::binary);
         IStreamWrapper isw(is);
         BaseReaderHandler<> h;
         Reader reader;
@@ -549,7 +549,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_IStreamWrapper_Setbuffere
         std::ifstream is;
         char buffer[65536];
         is.rdbuf()->pubsetbuf(buffer, sizeof(buffer));
-        is.open(filename_);
+        is.open(filename_, std::ios::in | std::ios::binary);
         IStreamWrapper isw(is);
         BaseReaderHandler<> h;
         Reader reader;

--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -454,32 +454,11 @@ TEST_F(RapidJson, FileReadStream) {
     }
 }
 
-TEST_F(RapidJson, FileReadStream_Unbuffered) {
-    for (size_t i = 0; i < kTrialCount; i++) {
-        FILE *fp = fopen(filename_, "rb");
-        FileReadStream s(fp);
-        while (s.Take() != '\0')
-            ;
-        fclose(fp);
-    }
-}
-
 TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_FileReadStream)) {
     for (size_t i = 0; i < kTrialCount; i++) {
         FILE *fp = fopen(filename_, "rb");
         char buffer[65536];
         FileReadStream s(fp, buffer, sizeof(buffer));
-        BaseReaderHandler<> h;
-        Reader reader;
-        reader.Parse(s, h);
-        fclose(fp);
-    }
-}
-
-TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_FileReadStream_Unbuffered)) {
-    for (size_t i = 0; i < kTrialCount; i++) {
-        FILE *fp = fopen(filename_, "rb");
-        FileReadStream s(fp);
         BaseReaderHandler<> h;
         Reader reader;
         reader.Parse(s, h);

--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -21,8 +21,11 @@
 #include "rapidjson/prettywriter.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/filereadstream.h"
+#include "rapidjson/istreamwrapper.h"
 #include "rapidjson/encodedstream.h"
 #include "rapidjson/memorystream.h"
+
+#include <fstream>
 
 #ifdef RAPIDJSON_SSE2
 #define SIMD_SUFFIX(name) name##_SSE2
@@ -451,6 +454,16 @@ TEST_F(RapidJson, FileReadStream) {
     }
 }
 
+TEST_F(RapidJson, FileReadStream_Unbuffered) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        FILE *fp = fopen(filename_, "rb");
+        FileReadStream s(fp);
+        while (s.Take() != '\0')
+            ;
+        fclose(fp);
+    }
+}
+
 TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_FileReadStream)) {
     for (size_t i = 0; i < kTrialCount; i++) {
         FILE *fp = fopen(filename_, "rb");
@@ -460,6 +473,88 @@ TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_FileReadStream)) {
         Reader reader;
         reader.Parse(s, h);
         fclose(fp);
+    }
+}
+
+TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_FileReadStream_Unbuffered)) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        FILE *fp = fopen(filename_, "rb");
+        FileReadStream s(fp);
+        BaseReaderHandler<> h;
+        Reader reader;
+        reader.Parse(s, h);
+        fclose(fp);
+    }
+}
+
+TEST_F(RapidJson, IStreamWrapper) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        std::ifstream is(filename_);
+        char buffer[65536];
+        IStreamWrapper isw(is, buffer, sizeof(buffer));
+        while (isw.Take() != '\0')
+            ;
+        is.close();
+    }
+}
+
+TEST_F(RapidJson, IStreamWrapper_Unbuffered) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        std::ifstream is(filename_);
+        IStreamWrapper isw(is);
+        while (isw.Take() != '\0')
+            ;
+        is.close();
+    }
+}
+
+TEST_F(RapidJson, IStreamWrapper_Setbuffered) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        std::ifstream is;
+        char buffer[65536];
+        is.rdbuf()->pubsetbuf(buffer, sizeof(buffer));
+        is.open(filename_);
+        IStreamWrapper isw(is);
+        while (isw.Take() != '\0')
+            ;
+        is.close();
+    }
+}
+
+TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_IStreamWrapper)) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        std::ifstream is(filename_);
+        char buffer[65536];
+        IStreamWrapper isw(is, buffer, sizeof(buffer));
+        BaseReaderHandler<> h;
+        Reader reader;
+        reader.Parse(isw, h);
+        is.close();
+    }
+}
+
+TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_IStreamWrapper_Unbuffered)) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        std::ifstream is(filename_);
+        IStreamWrapper isw(is);
+        BaseReaderHandler<> h;
+        Reader reader;
+        reader.Parse(isw, h);
+        is.close();
+    }
+}
+
+TEST_F(RapidJson, SIMD_SUFFIX(ReaderParse_DummyHandler_IStreamWrapper_Setbuffered)) {
+    for (size_t i = 0; i < kTrialCount; i++) {
+        std::ifstream is;
+        char buffer[65536];
+        is.rdbuf()->pubsetbuf(buffer, sizeof(buffer));
+        is.open(filename_);
+        IStreamWrapper isw(is);
+        BaseReaderHandler<> h;
+        Reader reader;
+        reader.Parse(isw, h);
+        is.close();
     }
 }
 


### PR DESCRIPTION
On (my) linux, perftest reports:
- ~40% gain for FileReadStream (`FileReadStream::Take()` loop),
- ~10% gain for ReaderParse_DummyHandler_FileReadStream.

With the same logic applied to BasicIStreamWrapper, which thus can now
also be created with a user buffer, performances align with those of
FileReadStream (see below, and as also noticed in #1365).

The "unbuffered" versions (added for FileReadStream) work solely with
the internal peekBuffer (Ch[4]) and are measured in perftest.  When
performances don't matter much, they can avoid the use of large
stack/heap buffers.

Though `appveyor` will probably have more trustworthy/relevant numbers, here are some from `perftest` on my linux laptop.

Codebase:
```
[ RUN      ] RapidJson.FileReadStream
[       OK ] RapidJson.FileReadStream (3292 ms)
[ RUN      ] RapidJson.FileReadStream_Unbuffered
[       OK ] RapidJson.FileReadStream_Unbuffered (6096 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_FileReadStream_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_FileReadStream_SSE42 (8089 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_FileReadStream_Unbuffered_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_FileReadStream_Unbuffered_SSE42 (10856 ms)
[ RUN      ] RapidJson.IStreamWrapper_Unbuffered
[       OK ] RapidJson.IStreamWrapper_Unbuffered (6383 ms)
[ RUN      ] RapidJson.IStreamWrapper_Setbuffered
[       OK ] RapidJson.IStreamWrapper_Setbuffered (6300 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_Unbuffered_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_Unbuffered_SSE42 (16108 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_Setbuffered_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_Setbuffered_SSE42 (15516 ms)
```

New code:
```
[ RUN      ] RapidJson.FileReadStream
[       OK ] RapidJson.FileReadStream (1889 ms)
[ RUN      ] RapidJson.FileReadStream_Unbuffered
[       OK ] RapidJson.FileReadStream_Unbuffered (4284 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_FileReadStream_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_FileReadStream_SSE42 (7257 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_FileReadStream_Unbuffered_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_FileReadStream_Unbuffered_SSE42 (10278 ms)
[ RUN      ] RapidJson.IStreamWrapper
[       OK ] RapidJson.IStreamWrapper (1871 ms)
[ RUN      ] RapidJson.IStreamWrapper_Unbuffered
[       OK ] RapidJson.IStreamWrapper_Unbuffered (4926 ms)
[ RUN      ] RapidJson.IStreamWrapper_Setbuffered
[       OK ] RapidJson.IStreamWrapper_Setbuffered (4920 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_SSE42 (7266 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_Unbuffered_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_Unbuffered_SSE42 (10844 ms)
[ RUN      ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_Setbuffered_SSE42
[       OK ] RapidJson.ReaderParse_DummyHandler_IStreamWrapper_Setbuffered_SSE42 (10557 ms)
```

The "_Setbuffered" tests show how it does not help (much) to set a custom/large `std::filebuf` to the `std::ifstream`. This is quite expected in the new code since reads are limited to `sizeof(peekBuffer_)` anyway, but even in codebase where `IStreamWrapper::Take()` calls `ifstream::get()` directly there is no/few improvement (the results for codebase come from simply/only adding this PR's "_SetBuffered" tests there).