### PR TITLE
Use the allocator of the Schema for its Pointer.

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -409,7 +409,7 @@ public:
     Schema(SchemaDocumentType* schemaDocument, const PointerType& p, const ValueType& value, const ValueType& document, AllocatorType* allocator) :
         allocator_(allocator),
         uri_(schemaDocument->GetURI(), *allocator),
-        pointer_(p),
+        pointer_(p, allocator),
         typeless_(schemaDocument->GetTypeless()),
         enum_(),
         enumCount_(),


### PR DESCRIPTION
The Pointer passed to construct the Schema can be from the stack or any
transient storage, so the copy stored in the Schema must have the same
lifetime/allocator as the Schema itself.