### PR TITLE
add missing header "ios"

### DIFF
--- a/include/rapidjson/istreamwrapper.h
+++ b/include/rapidjson/istreamwrapper.h
@@ -17,6 +17,7 @@
 
 #include "stream.h"
 #include <iosfwd>
+#include <ios>
 
 #ifdef __clang__
 RAPIDJSON_DIAG_PUSH


### PR DESCRIPTION
add missing header "ios" for the symbol "std:: streamsize"