### PR TITLE
Fix missing dot in printf format

### DIFF
--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -1848,7 +1848,7 @@ TEST(SchemaValidator, TestSuite) {
                                 validator.Reset();
                                 bool actual = data.Accept(validator);
                                 if (expected != actual)
-                                    printf("Fail: %30s \"%s\" \"%s\"\n", filename, description1, description2);
+                                    printf("Fail: %.30s \"%s\" \"%s\"\n", filename, description1, description2);
                                 else
                                     passCount++;
                             }


### PR DESCRIPTION
Probably this is what someone means. In Python such format is ok, but not in C/C++