### PR TITLE
Fixed a build issue by initializing "index" in the header file

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -899,7 +899,7 @@ public:
                 }
         }
 
-        SizeType index;
+        SizeType index  = 0;
         if (FindPropertyIndex(ValueType(str, len).Move(), &index)) {
             if (context.patternPropertiesSchemaCount > 0) {
                 context.patternPropertiesSchemas[context.patternPropertiesSchemaCount++] = properties_[index].schema;


### PR DESCRIPTION
Build on CentOS 6 was failing due to an uninitialized SizeType variable "index".   Initialized it to 0 to prevent the warning (which was being treated as an error)