### PR TITLE
Delete redundant statements

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1514,7 +1514,7 @@ public:
         RAPIDJSON_ASSERT(first <= last);
         RAPIDJSON_ASSERT(last <= MemberEnd());
 
-        MemberIterator pos = MemberBegin() + (first - MemberBegin());
+        MemberIterator pos = first;
         for (MemberIterator itr = pos; itr != last; ++itr)
             itr->~Member();
         std::memmove(static_cast<void*>(&*pos), &*last, static_cast<size_t>(MemberEnd() - last) * sizeof(Member));


### PR DESCRIPTION
如果这句话`MemberIterator pos = MemberBegin() + (first - MemberBegin());` 没有其他的作用，应该可以精简一下，直接写成`MemberIterator pos = first`吧。