### PR TITLE
Make GenericMemberIterator::Iterator public again (RAPIDJSON_NOMEMBER…

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -210,12 +210,14 @@ class GenericMemberIterator;
 //! non-const GenericMemberIterator
 template <typename Encoding, typename Allocator>
 class GenericMemberIterator<false,Encoding,Allocator> {
+public:
     //! use plain pointer as iterator type
     typedef GenericMember<Encoding,Allocator>* Iterator;
 };
 //! const GenericMemberIterator
 template <typename Encoding, typename Allocator>
 class GenericMemberIterator<true,Encoding,Allocator> {
+public:
     //! use plain const pointer as iterator type
     typedef const GenericMember<Encoding,Allocator>* Iterator;
 };


### PR DESCRIPTION
…ITERATORCLASS)

d87b698d0f made all definitions of GenericMemberIterator consistent as
classes (they were structs with RAPIDJSON_NOMEMBERITERATORCLASS
defined), but it didn't keep the member definitions public.

document.h:586:71: error: 'Iterator' is a private member of
      'rapidjson::GenericMemberIterator<false, rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >'
    typedef typename GenericMemberIterator<false,Encoding,Allocator>::Iterator MemberIterator;  //!< Member iterator for i...
                                                                      ^
document.h:2124:32: note: in instantiation of template class
      'rapidjson::GenericValue<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator> >' requested here
class GenericDocument : public GenericValue<Encoding, Allocator> {