### PR TITLE
Implement BufferedOStreamWrapper

### DIFF
--- a/include/rapidjson/bufferedostreamwrapper.h
+++ b/include/rapidjson/bufferedostreamwrapper.h
@@ -1,0 +1,224 @@
+// Tencent is pleased to support the open source community by making RapidJSON available.
+//
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the
+// specific language governing permissions and limitations under the License.
+
+#ifndef RAPIDJSON_BUFFEREDOSTREAMWRAPPER_H_
+#define RAPIDJSON_BUFFEREDOSTREAMWRAPPER_H_
+
+#include <iosfwd>
+
+#include "writer.h"
+
+#if defined(__clang__)
+RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
+
+RAPIDJSON_NAMESPACE_BEGIN
+
+template<typename Stream = std::ostream, typename Allocator = CrtAllocator>
+class BufferedOStreamWrapper {
+public:
+    typedef typename Stream::char_type Ch;
+    explicit BufferedOStreamWrapper(Stream &stream, Allocator *allocator = nullptr)
+            : stream_(stream), allocator_(allocator) {}
+
+    ~BufferedOStreamWrapper() {
+        Flush();
+
+        Allocator::Free(top_);
+        RAPIDJSON_DELETE(ownAllocator_);
+    }
+
+    BufferedOStreamWrapper(const BufferedOStreamWrapper &) = delete;
+    BufferedOStreamWrapper &operator=(const BufferedOStreamWrapper &) = delete;
+
+    void Put(Ch c) {
+        ReserveMore(1);
+        PutUnsafe(c);
+    }
+
+    void PutUnsafe(Ch c) {
+        *end_ = c;
+        ++end_;
+    }
+
+    Ch *Push(size_t cnt) {
+        ReserveMore(cnt);
+        auto *const res = end_;
+        end_ += cnt;
+        return res;
+    }
+
+    // Can pop only as many elements as was pushed the last time
+    void Pop(size_t cnt) { end_ -= cnt; }
+
+    void Flush() {
+        FlushInternal();
+        stream_.flush();
+    }
+
+    // Not implemented
+    [[nodiscard]] char Peek() const {
+        RAPIDJSON_ASSERT(false);
+        return 0;
+    }
+
+    char Take() {
+        RAPIDJSON_ASSERT(false);
+        return 0;
+    }
+
+    [[nodiscard]] size_t Tell() const {
+        RAPIDJSON_ASSERT(false);
+        return 0;
+    }
+    char *PutBegin() {
+        RAPIDJSON_ASSERT(false);
+        return nullptr;
+    }
+    size_t PutEnd(char *) {
+        RAPIDJSON_ASSERT(false);
+        return 0;
+    }
+
+    void ReserveMore(size_t extra_cnt) {
+        if (RAPIDJSON_LIKELY(GetBufLeftCapacity() >= extra_cnt))
+            return;
+
+        const size_t cur_capacity = GetBufCapacity();
+
+        if (cur_capacity >= kMaxBufSize) {
+            FlushInternal();
+            if (extra_cnt > cur_capacity) {
+                Resize(extra_cnt);
+            }
+        } else if (top_ == nullptr) {
+            FirstAllocMemory(extra_cnt);
+        } else {
+            Resize(extra_cnt);
+        }
+    }
+
+private:
+    static const size_t kMaxBufSize = 1024 * 1;
+    static const size_t kInitialBufSize = 64;
+    Stream &stream_;
+
+    Ch *top_ = nullptr;
+    Ch *end_ = nullptr;
+    Ch *capacity_end_ = nullptr;
+
+    Allocator *allocator_ = nullptr;
+    Allocator *ownAllocator_ = nullptr;
+
+    void ClearBuf() { end_ = top_; }
+
+    void FirstAllocMemory(size_t cnt) {
+        if (allocator_ == nullptr) {
+            ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator());
+        }
+
+        size_t capacity = kInitialBufSize;
+        while (capacity < cnt) {
+            capacity *= 2;
+        }
+
+        end_ = top_ =
+                reinterpret_cast<Ch *>(allocator_->Malloc(capacity * sizeof(Ch)));
+        capacity_end_ = top_ + capacity;
+    }
+
+    void Resize(size_t extra_cnt) {
+        const size_t cur_size = GetBufSize();
+        const size_t cur_cap = GetBufCapacity();
+        size_t new_cap = cur_cap;
+        const size_t required_cap = cur_size + extra_cnt;
+        do {
+            new_cap *= 2;
+        } while (required_cap > new_cap);
+
+        top_ = reinterpret_cast<Ch *>(allocator_->Realloc(top_, cur_cap, new_cap));
+        end_ = top_ + cur_size;
+        capacity_end_ = top_ + new_cap;
+    }
+
+    size_t GetBufLeftCapacity() const {
+        return static_cast<size_t>(capacity_end_ - end_) / sizeof(Ch);
+    }
+    size_t GetBufCapacity() const {
+        return static_cast<size_t>(capacity_end_ - top_) / sizeof(Ch);
+    }
+    size_t GetBufSize() const {
+        return static_cast<size_t>(end_ - top_) / sizeof(Ch);
+    }
+
+    void FlushInternal() {
+        stream_.write(top_, static_cast<std::streamsize>(GetBufSize()));
+        ClearBuf();
+    }
+};
+
+template<typename Allocator>
+inline void PutReserve(BufferedOStreamWrapper<Allocator> &stream, size_t count) {
+    stream.ReserveMore(count);
+}
+
+template<typename Allocator>
+inline void PutUnsafe(BufferedOStreamWrapper<Allocator> &stream,
+                      typename BufferedOStreamWrapper<Allocator>::Ch c) {
+    stream.PutUnsafe(c);
+}
+
+//! Implement specialized version of PutN() with memset() for better
+//! performance.
+template<typename Allocator>
+inline void PutN(BufferedOStreamWrapper<Allocator> &stream,
+                 typename BufferedOStreamWrapper<Allocator>::Ch c, size_t n) {
+    std::memset(stream.Push(n), c, n * sizeof(c));
+}
+
+// Full specialization for Writer<BufferedOStreamWrapper<>> to prevent memory copying
+
+template<>
+inline bool Writer<BufferedOStreamWrapper<>>::WriteInt(int i) {
+    return internal::WriteIntToStream(i, os_);
+}
+
+template<>
+inline bool Writer<BufferedOStreamWrapper<>>::WriteUint(unsigned u) {
+    return internal::WriteUintToStream(u, os_);
+}
+
+template<>
+inline bool Writer<BufferedOStreamWrapper<>>::WriteInt64(int64_t i64) {
+    return internal::WriteInt64ToStream(i64, os_);
+}
+
+template<>
+inline bool Writer<BufferedOStreamWrapper<>>::WriteUint64(uint64_t u) {
+    return internal::WriteUint64ToStream(u, os_);
+}
+
+template<>
+inline bool Writer<BufferedOStreamWrapper<>>::WriteDouble(double d) {
+    return internal::WriteDoubleToStream(d, os_, maxDecimalPlaces_);
+}
+
+RAPIDJSON_NAMESPACE_END
+
+#if defined(__clang__)
+RAPIDJSON_DIAG_POP
+#endif
+
+#endif // RAPIDJSON_BUFFEREDOSTREAMWRAPPER_H_

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -3,6 +3,7 @@ include(CheckCXXCompilerFlag)
 set(UNITTEST_SOURCES
 	allocatorstest.cpp
     bigintegertest.cpp
+    bufferedostremwrappertest.cpp
 	cursorstreamwrappertest.cpp
     documenttest.cpp
     dtoatest.cpp

--- a/test/unittest/bufferedostremwrappertest.cpp
+++ b/test/unittest/bufferedostremwrappertest.cpp
@@ -1,0 +1,238 @@
+// Tencent is pleased to support the open source community by making RapidJSON available.
+// 
+// Copyright (C) 2015 THL A29 Limited, a Tencent company, and Milo Yip. All rights reserved.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+
+#include "unittest.h"
+
+#include "rapidjson/document.h"
+#include "rapidjson/reader.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/bufferedostreamwrapper.h"
+#include "rapidjson/memorybuffer.h"
+
+#include <sstream>
+#include <fstream>
+
+#ifdef __clang__
+RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(c++98-compat)
+#endif
+
+using namespace rapidjson;
+
+typedef BufferedOStreamWrapper<> StreamWrapper;
+
+TEST(BufferedOStreamWrapper, UseInWriter) {
+    StringStream s
+            ("{ \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] } ");
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+        Writer<StreamWrapper> writer(buffer);
+
+        Reader reader;
+        reader.Parse<0>(s, writer);
+    }
+    EXPECT_STREQ(
+            "{\"hello\":\"world\",\"t\":true,\"f\":false,\"n\":null,\"i\":123,\"pi\":3.1416,\"a\":[1,2,3]}",
+            ss.str().c_str());
+}
+
+TEST(BufferedOStreamWrapper, InitialSize) {
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+        EXPECT_EQ("", ss.str());
+    }
+    EXPECT_EQ("", ss.str());
+}
+
+TEST(BufferedOStreamWrapper, Put) {
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+        buffer.Put('A');
+    }
+
+    EXPECT_EQ("A", ss.str());
+}
+
+static std::string GenerateLongString(size_t len) {
+    static const std::string
+            PATTER = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    std::string res;
+    for (size_t i = 0; i < len / PATTER.size(); ++i) {
+        res += PATTER;
+    }
+
+    const size_t left_size = len - res.size();
+    res += PATTER.substr(0, left_size);
+
+    return res;
+}
+
+TEST(BufferedOStreamWrapper, RepeatedPut) {
+    const std::string source = GenerateLongString(65000);
+
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+
+        for (size_t i = 0, len = source.size(); i < len; ++i) {
+            buffer.Put(source[i]);
+        }
+    }
+
+    EXPECT_EQ(source, ss.str());
+}
+
+TEST(BufferedOStreamWrapper, Push5) {
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+        char *buf = buffer.Push(5);
+        memset(buf, ' ', 5);
+    }
+
+    EXPECT_EQ(std::string(5, ' '), ss.str());
+}
+
+TEST(BufferedOStreamWrapper, Push65536) {
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+        memset(buffer.Push(65536u), '_', 65536u);
+    }
+
+    EXPECT_EQ(std::string(65536u, '_'), ss.str());
+}
+
+TEST(BufferedOStreamWrapper, Push5Then65536) {
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+        memset(buffer.Push(5), ' ', 5);
+        memset(buffer.Push(65536u), '_', 65536u);
+    }
+
+    EXPECT_EQ(std::string(5, ' ') + std::string(65536u, '_'), ss.str());
+}
+
+TEST(BufferedOStreamWrapper, RepeatedPush) {
+    const size_t chunk_size = 53;
+    const std::string source = GenerateLongString(chunk_size * 1000);
+
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+
+        for (size_t i = 0, len = source.size(); i < len; i += chunk_size) {
+            memcpy(buffer.Push(chunk_size), source.c_str() + i, chunk_size);
+        }
+    }
+
+    EXPECT_EQ(source, ss.str());
+}
+
+TEST(BufferedOStreamWrapper, Pop) {
+    std::stringstream ss;
+    {
+        StreamWrapper buffer(ss);
+        memcpy(buffer.Push(5), "ABCDE", 5);
+        buffer.Pop(3);
+    }
+
+    EXPECT_EQ("AB", ss.str());
+}
+
+TEST(BufferedOStreamWrapper, Flush) {
+    std::stringstream ss;
+    StreamWrapper buffer(ss);
+    memcpy(buffer.Push(6), "abcdef", 6);
+    buffer.Flush();
+
+    EXPECT_EQ("abcdef", ss.str());
+}
+
+template <typename StringStreamType>
+static void TestStringStream() {
+    typedef typename StringStreamType::char_type Ch;
+
+    Ch s[] = { 'A', 'B', 'C', '\0' };
+    StringStreamType oss(s);
+    BufferedOStreamWrapper<StringStreamType> os(oss);
+    for (size_t i = 0; i < 3; i++)
+        os.Put(s[i]);
+    os.Flush();
+    for (size_t i = 0; i < 3; i++)
+        EXPECT_EQ(s[i], oss.str()[i]);
+}
+
+TEST(BufferedOStreamWrapper, ostringstream) {
+    TestStringStream<std::ostringstream>();
+}
+
+TEST(BufferedOStreamWrapper, stringstream) {
+    TestStringStream<std::stringstream>();
+}
+
+TEST(BufferedOStreamWrapper, wostringstream) {
+    TestStringStream<std::wostringstream>();
+}
+
+TEST(BufferedOStreamWrapper, wstringstream) {
+    TestStringStream<std::wstringstream>();
+}
+
+TEST(BufferedOStreamWrapper, cout) {
+    BufferedOStreamWrapper<> os(std::cout);
+    const char* s = "Hello World!\n";
+    while (*s)
+        os.Put(*s++);
+    os.Flush();
+}
+
+template <typename FileStreamType>
+static void TestFileStream() {
+    char filename[L_tmpnam];
+    FILE* fp = TempFile(filename);
+    fclose(fp);
+
+    const char* s = "Hello World!\n";
+    {
+        FileStreamType ofs(filename, std::ios::out | std::ios::binary);
+        BufferedOStreamWrapper<FileStreamType> osw(ofs);
+        for (const char* p = s; *p; p++)
+            osw.Put(*p);
+        osw.Flush();
+    }
+
+    fp = fopen(filename, "r");
+    ASSERT_TRUE( fp != NULL );
+    for (const char* p = s; *p; p++)
+        EXPECT_EQ(*p, static_cast<char>(fgetc(fp)));
+    fclose(fp);
+}
+
+TEST(BufferedOStreamWrapper, ofstream) {
+    TestFileStream<std::ofstream>();
+}
+
+TEST(BufferedOStreamWrapper, fstream) {
+    TestFileStream<std::fstream>();
+}
+
+
+#ifdef __clang__
+RAPIDJSON_DIAG_POP
+#endif


### PR DESCRIPTION
It is about 3-4 times faster than `BasicOStreamWrapper`.

Even though OStreamWrapper is not the main way to use `rapidjson`, sometimes you have to use it. An example of such usage might be the `cereal` project. It uses `OStreamWrapper` for its `json` archive.

And so the fact that it is 3-4 times slower than `BufferString` might be a problem.

The new class can be an alternative when you, due to some reasons, have to use `std::ostream`, and still need the performance.

To test performance I used the following benchmark: [rapidjson-ostream-wrapper-benchmark.cpp](https://gist.github.com/willir/4c97942b26b51ae9c72d21f80e54805a). On my pc it outputs:

```
--------------------------------------------------------------------------
Benchmark                                Time             CPU   Iterations
--------------------------------------------------------------------------
BenchmarkStringBuffer              2548875 ns      2548972 ns          270
BenchmarkBufferedOStreamWrapper    2872227 ns      2872338 ns          241
BenchmarkOStreamWrapper           10014101 ns     10014363 ns           68
```
