### PR TITLE
Adding Meson Build file for easy including into other meson C++ projects

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,4 @@
+project('rapidjson', 'cpp', version: '1.1.0', license: 'MIT')
+
+rapidjson_inc = include_directories('include')
+rapidjson_dep = declare_dependency(include_directories: rapidjson_inc)


### PR DESCRIPTION
Simple Meson.build file presents the library as a dependency that can be added to other Meson builds