### PR TITLE
Check before really encoding code points by default.

### DIFF
--- a/include/rapidjson/encodings.h
+++ b/include/rapidjson/encodings.h
@@ -691,6 +691,8 @@ struct AutoUTF {
 
     \tprarm CodePointValidation Run validate before encode or not.
 */
+// By default, This Encoder will validate code point and generate parse error.
+// Users can switch the check feature off by set 'CodePointValidation' to 'false'.
 template<bool CodePointValidation = true>
 class ValidatableEncoder {
 public:
@@ -701,7 +703,6 @@ public:
     static bool EncodeUnsafe(OutputStream &os, unsigned codepoint);
 };
 
-// By default, reader will validate code point and generate parse error.
 template<bool CodePointValidation>
 template<typename TEncoding, typename OutputStream>
 bool
@@ -724,7 +725,6 @@ ValidatableEncoder<CodePointValidation>::EncodeUnsafe(OutputStream &os, unsigned
     return true;
 }
 
-// Users can switch the check feature off by set 'CodePointValidation' to 'false'.
 template<>
 template<typename TEncoding, typename OutputStream>
 bool
@@ -733,7 +733,6 @@ ValidatableEncoder<false>::Encode(OutputStream &os, unsigned codepoint) {
     return true;
 }
 
-// Users can switch the check feature off by set 'CodePointValidation' to 'false'.
 template<>
 template<typename TEncoding, typename OutputStream>
 bool

--- a/include/rapidjson/encodings.h
+++ b/include/rapidjson/encodings.h
@@ -695,10 +695,10 @@ template<bool CodePointValidation = true>
 class ValidatableEncoder {
 public:
     template<typename TEncoding, typename OutputStream>
-    static RAPIDJSON_FORCEINLINE bool Encode(OutputStream &os, unsigned codepoint);
+    static bool Encode(OutputStream &os, unsigned codepoint);
 
     template<typename TEncoding, typename OutputStream>
-    static RAPIDJSON_FORCEINLINE bool EncodeUnsafe(OutputStream &os, unsigned codepoint);
+    static bool EncodeUnsafe(OutputStream &os, unsigned codepoint);
 };
 
 // By default, reader will validate code point and generate parse error.

--- a/include/rapidjson/fwd.h
+++ b/include/rapidjson/fwd.h
@@ -31,7 +31,7 @@ template<typename CharType> struct UTF32LE;
 template<typename CharType> struct ASCII;
 template<typename CharType> struct AutoUTF;
 
-template<typename SourceEncoding, typename TargetEncoding>
+template<typename SourceEncoding, typename TargetEncoding, bool CodePointValidation>
 struct Transcoder;
 
 // allocators.h

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1028,7 +1028,7 @@ private:
                             RAPIDJSON_PARSE_ERROR(kParseErrorStringUnicodeSurrogateInvalid, escapeOffset);
                         codepoint = (((codepoint - 0xD800) << 10) | (codepoint2 - 0xDC00)) + 0x10000;
                     }
-                    if (!ValidatableEncoder<parseFlags & kParseValidateEncodingFlag>::template Encode<TEncoding>(os, codepoint))
+                    if (!ValidatableEncoder<static_cast<bool>(parseFlags & kParseValidateEncodingFlag)>::template Encode<TEncoding>(os, codepoint))
                     {
                         RAPIDJSON_PARSE_ERROR(kParseErrorStringInvalidEncoding, escapeOffset);
                     }

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1028,7 +1028,10 @@ private:
                             RAPIDJSON_PARSE_ERROR(kParseErrorStringUnicodeSurrogateInvalid, escapeOffset);
                         codepoint = (((codepoint - 0xD800) << 10) | (codepoint2 - 0xDC00)) + 0x10000;
                     }
-                    TEncoding::Encode(os, codepoint);
+                    if (!ValidatableEncoder<parseFlags & kParseValidateEncodingFlag>::template Encode<TEncoding>(os, codepoint))
+                    {
+                        RAPIDJSON_PARSE_ERROR(kParseErrorStringInvalidEncoding, escapeOffset);
+                    }
                 }
                 else
                     RAPIDJSON_PARSE_ERROR(kParseErrorStringEscapeInvalid, escapeOffset);

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -631,6 +631,11 @@ TEST(Document, Issue1604_ASCIIValidation) {
     EXPECT_EQ(kParseErrorStringInvalidEncoding, d.GetParseError());
 }
 
+TEST(DocumentDeathTest, Issue1604_ASCIIValidation) {
+    GenericDocument<ASCII<>> d_no_check;
+    ASSERT_THROW((d_no_check.Parse("\"\\u1234\"")), AssertException);
+}
+
 // This test does not properly use parsing, just for testing.
 // It must call ClearStack() explicitly to prevent memory leak.
 // But here we cannot as ClearStack() is private.

--- a/test/unittest/encodingstest.cpp
+++ b/test/unittest/encodingstest.cpp
@@ -14,8 +14,6 @@
 
 #include "unittest.h"
 #include "rapidjson/filereadstream.h"
-#include "rapidjson/filewritestream.h"
-#include "rapidjson/encodedstream.h"
 #include "rapidjson/stringbuffer.h"
 
 using namespace rapidjson;
@@ -332,6 +330,12 @@ TEST(EncodingsTest, UTF8) {
             }
         }
     }
+
+    // Validate code point before encoding
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF8<>>(os, 0xFFFFFFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF8<>>(os, 0xFFFFFFFF));
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF8<>>(os, 0xFFFFFFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF8<>>(os, 0xFFFFFFFF), AssertException);
 }
 
 TEST(EncodingsTest, UTF16) {
@@ -392,6 +396,20 @@ TEST(EncodingsTest, UTF16) {
             }
         }
     }
+
+    // Validate code point before encoding
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<>>(os, 0xFFFFFFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<>>(os, 0xFFFFFFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<>>(os, 0xD800));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<>>(os, 0xD800));
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<>>(os, 0xDFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<>>(os, 0xDFFF));
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<>>(os, 0xFFFFFFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<>>(os, 0xFFFFFFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<>>(os, 0xD800), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<>>(os, 0xD800), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<>>(os, 0xDFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<>>(os, 0xDFFF), AssertException);
 }
 
 TEST(EncodingsTest, UTF32) {
@@ -423,6 +441,12 @@ TEST(EncodingsTest, UTF32) {
             }
         }
     }
+
+    // Validate code point before encoding
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF32<>>(os, 0xFFFFFFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF32<>>(os, 0xFFFFFFFF));
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF32<>>(os, 0xFFFFFFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF32<>>(os, 0xFFFFFFFF), AssertException);
 }
 
 TEST(EncodingsTest, ASCII) {
@@ -448,4 +472,10 @@ TEST(EncodingsTest, ASCII) {
             EXPECT_EQ(0, StrCmp(encodedStr, os2.GetString()));
         }
     }
+
+    // Validate code point before encoding
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<ASCII<>>(os, 0x0080));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<ASCII<>>(os, 0x0080));
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<ASCII<>>(os, 0x0080), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<ASCII<>>(os, 0x0080), AssertException);
 }

--- a/test/unittest/encodingstest.cpp
+++ b/test/unittest/encodingstest.cpp
@@ -332,10 +332,10 @@ TEST(EncodingsTest, UTF8) {
     }
 
     // Validate code point before encoding
-    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF8<>>(os, 0xFFFFFFFF));
-    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF8<>>(os, 0xFFFFFFFF));
-    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF8<>>(os, 0xFFFFFFFF), AssertException);
-    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF8<>>(os, 0xFFFFFFFF), AssertException);
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF8<> >(os, 0xFFFFFFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF8<> >(os, 0xFFFFFFFF));
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF8<> >(os, 0xFFFFFFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF8<> >(os, 0xFFFFFFFF), AssertException);
 }
 
 TEST(EncodingsTest, UTF16) {
@@ -398,18 +398,18 @@ TEST(EncodingsTest, UTF16) {
     }
 
     // Validate code point before encoding
-    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<>>(os, 0xFFFFFFFF));
-    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<>>(os, 0xFFFFFFFF));
-    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<>>(os, 0xD800));
-    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<>>(os, 0xD800));
-    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<>>(os, 0xDFFF));
-    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<>>(os, 0xDFFF));
-    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<>>(os, 0xFFFFFFFF), AssertException);
-    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<>>(os, 0xFFFFFFFF), AssertException);
-    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<>>(os, 0xD800), AssertException);
-    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<>>(os, 0xD800), AssertException);
-    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<>>(os, 0xDFFF), AssertException);
-    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<>>(os, 0xDFFF), AssertException);
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<> >(os, 0xFFFFFFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<> >(os, 0xFFFFFFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<> >(os, 0xD800));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<> >(os, 0xD800));
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF16<> >(os, 0xDFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF16<> >(os, 0xDFFF));
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<> >(os, 0xFFFFFFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<> >(os, 0xFFFFFFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<> >(os, 0xD800), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<> >(os, 0xD800), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF16<> >(os, 0xDFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF16<> >(os, 0xDFFF), AssertException);
 }
 
 TEST(EncodingsTest, UTF32) {
@@ -443,10 +443,10 @@ TEST(EncodingsTest, UTF32) {
     }
 
     // Validate code point before encoding
-    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF32<>>(os, 0xFFFFFFFF));
-    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF32<>>(os, 0xFFFFFFFF));
-    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF32<>>(os, 0xFFFFFFFF), AssertException);
-    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF32<>>(os, 0xFFFFFFFF), AssertException);
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<UTF32<> >(os, 0xFFFFFFFF));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<UTF32<> >(os, 0xFFFFFFFF));
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<UTF32<> >(os, 0xFFFFFFFF), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<UTF32<> >(os, 0xFFFFFFFF), AssertException);
 }
 
 TEST(EncodingsTest, ASCII) {
@@ -474,8 +474,8 @@ TEST(EncodingsTest, ASCII) {
     }
 
     // Validate code point before encoding
-    EXPECT_FALSE(ValidatableEncoder<>::Encode<ASCII<>>(os, 0x0080));
-    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<ASCII<>>(os, 0x0080));
-    EXPECT_THROW(ValidatableEncoder<false>::Encode<ASCII<>>(os, 0x0080), AssertException);
-    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<ASCII<>>(os, 0x0080), AssertException);
+    EXPECT_FALSE(ValidatableEncoder<>::Encode<ASCII<> >(os, 0x0080));
+    EXPECT_FALSE(ValidatableEncoder<>::EncodeUnsafe<ASCII<> >(os, 0x0080));
+    EXPECT_THROW(ValidatableEncoder<false>::Encode<ASCII<> >(os, 0x0080), AssertException);
+    EXPECT_THROW(ValidatableEncoder<false>::EncodeUnsafe<ASCII<> >(os, 0x0080), AssertException);
 }

--- a/test/unittest/fwdtest.cpp
+++ b/test/unittest/fwdtest.cpp
@@ -39,7 +39,7 @@ struct Foo {
     UTF32LE<unsigned>* utf32le;
     ASCII<char>* ascii;
     AutoUTF<unsigned>* autoutf;
-    Transcoder<UTF8<char>, UTF8<char> >* transcoder;
+    Transcoder<UTF8<char>, UTF8<char>, true>* transcoder;
 
     // allocators.h
     CrtAllocator* crtallocator;


### PR DESCRIPTION
Users can undef the macro 'VALIDATE_CODEPOINT' to disable this feature.