### PR TITLE
Remove shadow typedef

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -443,7 +443,6 @@ public:
         exclusiveMaximum_(false),
         defaultValueLength_(0)
     {
-        typedef typename SchemaDocumentType::ValueType ValueType;
         typedef typename ValueType::ConstValueIterator ConstValueIterator;
         typedef typename ValueType::ConstMemberIterator ConstMemberIterator;
 


### PR DESCRIPTION
Removes a duplicate and identical typedef that was causing a
'declaration shadows typedef' (-Wshadow) warning in clang.