### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,9 @@ Users can build and run the unit tests on their platform/compiler.
 
 RapidJSON is a header-only C++ library. Just copy the `include/rapidjson` folder to system or project's include path.
 
+Alternatively, if you are using the [vcpkg](https://github.com/Microsoft/vcpkg/) dependency manager you can download and install rapidjson with CMake integration in a single command:
+* vcpkg install rapidjson
+
 RapidJSON uses following software as its dependencies:
 * [CMake](https://cmake.org/) as a general build tool
 * (optional) [Doxygen](http://www.doxygen.org) to build documentation


### PR DESCRIPTION
RapidJSON is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build rapidjson, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for rapidjson and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.