### PR TITLE
Make GenericDocument attributes protected

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2512,6 +2512,7 @@ private:
     //! Prohibit assignment
     GenericDocument& operator=(const GenericDocument&);
 
+protected:
     void ClearStack() {
         if (Allocator::kNeedFree)
             while (stack_.GetSize() > 0)    // Here assumes all elements in stack array are GenericValue (Member is actually 2 GenericValue objects)


### PR DESCRIPTION
In order to be able to inherit from GenericDocument and use its
private variables (most importantly - have access to stack_),
the attributes are now declared protected instead of private.

One future use case (for ScyllaDB) involves creating a subclass
for GenericDocument, which overrides its Handler interface
(StartObject, EndObject, etc.), adding additional checks to prevent
too deeply nested JSON objects from being created.

Signed-off-by: Piotr Sarna <sarna@scylladb.com>