### PR TITLE
Fix building with Clang 10 and older libstdc++

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -24,9 +24,6 @@
 #include "encodedstream.h"
 #include <new>      // placement new
 #include <limits>
-#ifdef __cpp_impl_three_way_comparison
-#include <compare>
-#endif
 
 RAPIDJSON_DIAG_PUSH
 #ifdef __clang__
@@ -250,17 +247,23 @@ public:
 
     //! @name relations
     //@{
-#ifdef __cpp_impl_three_way_comparison
-    template <bool Const_> bool operator==(const GenericMemberIterator<Const_,Encoding,Allocator>& that) const { return ptr_ == that.ptr_; }
-    template <bool Const_> std::strong_ordering operator<=>(const GenericMemberIterator<Const_,Encoding,Allocator>& that) const { return ptr_ <=> that.ptr_; }
-#else
-    bool operator==(ConstIterator that) const { return ptr_ == that.ptr_; }
-    bool operator!=(ConstIterator that) const { return ptr_ != that.ptr_; }
-    bool operator<=(ConstIterator that) const { return ptr_ <= that.ptr_; }
-    bool operator>=(ConstIterator that) const { return ptr_ >= that.ptr_; }
-    bool operator< (ConstIterator that) const { return ptr_ < that.ptr_; }
-    bool operator> (ConstIterator that) const { return ptr_ > that.ptr_; }
-#endif
+    template <bool Const_>
+    bool operator==(GenericMemberIterator<Const_, Encoding, Allocator> that) const { return ptr_ == that.ptr_; }
+
+    template <bool Const_>
+    bool operator!=(GenericMemberIterator<Const_, Encoding, Allocator> that) const { return ptr_ != that.ptr_; }
+
+    template <bool Const_>
+    bool operator<=(GenericMemberIterator<Const_, Encoding, Allocator> that) const { return ptr_ <= that.ptr_; }
+
+    template <bool Const_>
+    bool operator>=(GenericMemberIterator<Const_, Encoding, Allocator> that) const { return ptr_ >= that.ptr_; }
+
+    template <bool Const_>
+    bool operator< (GenericMemberIterator<Const_, Encoding, Allocator> that) const { return ptr_ < that.ptr_; }
+
+    template <bool Const_>
+    bool operator> (GenericMemberIterator<Const_, Encoding, Allocator> that) const { return ptr_ > that.ptr_; }
     //@}
 
     //! @name dereference


### PR DESCRIPTION
libstdc++ doesn't provide `<compare>` header yet.
Revert 2661a17c7eaede and make comparison operator in GenericMemberIterator
templated.