### PR TITLE
Add NonConstIterator version for comparison operators

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -260,6 +260,13 @@ public:
     bool operator>=(ConstIterator that) const { return ptr_ >= that.ptr_; }
     bool operator< (ConstIterator that) const { return ptr_ < that.ptr_; }
     bool operator> (ConstIterator that) const { return ptr_ > that.ptr_; }
+
+    bool operator==(NonConstIterator that) const { return ptr_ == that.ptr_; }
+    bool operator!=(NonConstIterator that) const { return ptr_ != that.ptr_; }
+    bool operator<=(NonConstIterator that) const { return ptr_ <= that.ptr_; }
+    bool operator>=(NonConstIterator that) const { return ptr_ >= that.ptr_; }
+    bool operator< (NonConstIterator that) const { return ptr_ < that.ptr_; }
+    bool operator> (NonConstIterator that) const { return ptr_ > that.ptr_; }
 #endif
     //@}
 


### PR DESCRIPTION
Add NonConstIterator version for comparison operators to eliminate CLang 10 compile error