### PR TITLE
Fix CLang 10 compile error

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -24,7 +24,7 @@
 #include "encodedstream.h"
 #include <new>      // placement new
 #include <limits>
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
 #include <compare>
 #endif
 
@@ -250,7 +250,7 @@ public:
 
     //! @name relations
     //@{
-#ifdef __cpp_impl_three_way_comparison
+#ifdef __cpp_lib_three_way_comparison
     template <bool Const_> bool operator==(const GenericMemberIterator<Const_,Encoding,Allocator>& that) const { return ptr_ == that.ptr_; }
     template <bool Const_> std::strong_ordering operator<=>(const GenericMemberIterator<Const_,Encoding,Allocator>& that) const { return ptr_ <=> that.ptr_; }
 #else


### PR DESCRIPTION
__cpp_impl_three_way_comparison is used to check if the compiler supports three-way comparison, but the <compare> header is only available if __cpp_lib_three_way_comparison is defined.

For more info look at https://en.cppreference.com/w/User:D41D8CD98F/feature_testing_macros