### PR TITLE
Add CMake minimum version required.

### DIFF
--- a/RapidJSONConfig.cmake.in
+++ b/RapidJSONConfig.cmake.in
@@ -1,4 +1,8 @@
 ################################################################################
+# CMake minimum version required
+cmake_minimum_required(VERSION 3.0)
+
+################################################################################
 # RapidJSON source dir
 set( RapidJSON_SOURCE_DIR "@CONFIG_SOURCE_DIR@")
 


### PR DESCRIPTION
Interface Libraries feature is not available before CMake 3.0

If we add `find_package(RapidJSON)` in CMakeLists.txt and use old cmake to build the project, the cmake progress will failed:

```
CMake Error at CMakeLists.txt:xx (add_library):     
  Cannot find source file:   
         INTERFACE
  Tried extensions .c .C .c++ .cc .cpp .cxx .m .M .mm .h .hh .h++ .hm .hpp .hxx .in .txx     
```

This feature is only available after CMake 3.0, see [this discussion](https://github.com/emil-e/rapidcheck/issues/163) for detail.