### PR TITLE
Correct object copying in document.h

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -113,7 +113,7 @@ template <typename Encoding, typename Allocator>
 class GenericMember {
 public:
     // Allow default construction as it is needed during copying.
-    GenericMember() = default;
+    GenericMember() {}
 
     GenericValue<Encoding, Allocator> name;     //!< name of member (must be a string)
     GenericValue<Encoding, Allocator> value;    //!< value of member.


### PR DESCRIPTION
 - this came up when building the code with GCC9
   + copying C++ objects with memcpy() is only permitted for Trivial types, the rest
     should be copied via copy or assignment
   + tweaked the code to construct the objects in place and then assign

Ran "make test", looks OK.

Fixes #1700