### PR TITLE
Optimize GenericValue::operator==  with string literal.

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -22,6 +22,7 @@
 #include "internal/strfunc.h"
 #include "memorystream.h"
 #include "encodedstream.h"
+#include "typetraits.h"
 #include <new>      // placement new
 #include <limits>
 #ifdef __cpp_lib_three_way_comparison
@@ -1053,7 +1054,31 @@ public:
     }
 
     //! Equal-to operator with const C-string pointer
-    bool operator==(const Ch* rhs) const { return *this == GenericValue(StringRef(rhs)); }
+    template<class StringType, std::enable_if_t<IsSpecificString<Ch, StringType>::value, int> = 1>
+    bool operator==(const StringType& rhs) const
+    {
+        if constexpr(IsSpecificStringLiteral<Ch, StringType>::value)
+        {
+            /*constexpr*/ SizeType N = std::extent<StringType>::value;
+            return *this == GenericValue(StringRef(rhs, N - 1));
+        }
+        return *this == GenericValue(StringRef(rhs));
+    }
+
+    //! Equal-to operator with primitive types
+    /*! \tparam T Either \ref Type, \c int, \c unsigned, \c int64_t, \c uint64_t, \c double, \c true, \c false
+    */
+    template <typename T, std::enable_if_t<!IsSpecificString<Ch, T>::value, int> = 1>
+    RAPIDJSON_DISABLEIF_RETURN(
+        (
+//internal::OrExpr<
+            internal::OrExpr<internal::IsPointer<T>, internal::IsGenericValue<T> >
+//            , IsSpecificString<Ch, T>
+//>
+            ), (bool))
+    operator==(const T& rhs) const
+    { return *this == GenericValue(rhs); }
+
 
 #if RAPIDJSON_HAS_STDSTRING
     //! Equal-to operator with string object
@@ -1061,11 +1086,6 @@ public:
      */
     bool operator==(const std::basic_string<Ch>& rhs) const { return *this == GenericValue(StringRef(rhs)); }
 #endif
-
-    //! Equal-to operator with primitive types
-    /*! \tparam T Either \ref Type, \c int, \c unsigned, \c int64_t, \c uint64_t, \c double, \c true, \c false
-    */
-    template <typename T> RAPIDJSON_DISABLEIF_RETURN((internal::OrExpr<internal::IsPointer<T>,internal::IsGenericValue<T> >), (bool)) operator==(const T& rhs) const { return *this == GenericValue(rhs); }
 
     //! Not-equal-to operator
     /*! \return !(*this == rhs)

--- a/include/rapidjson/typetraits.h
+++ b/include/rapidjson/typetraits.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <type_traits>
+
+#include "rapidjson.h"
+
+RAPIDJSON_NAMESPACE_BEGIN
+
+template<class CharType, SizeType N>
+using StringLiteral = CharType[N];
+
+template<class T>
+using remove_cvref = std::remove_const<std::remove_volatile_t<std::remove_reference_t<T>>>;
+template<class T>
+using remove_cvref_t = typename remove_cvref<T>::type;
+
+namespace impl
+{
+    // match unknown types
+    template<class ExceptedCharType, class T>
+    struct IsSpecificStringLiteral :std::false_type {};
+
+    // match StringLiteral with different CharType
+    template<class ExceptedCharType, class SuppliedCharType, SizeType N>
+    struct IsSpecificStringLiteral<
+        ExceptedCharType, StringLiteral<SuppliedCharType, N>>
+        :std::false_type{};
+
+    // excepted match
+    template<class ExceptedCharType, SizeType N>
+    struct IsSpecificStringLiteral<
+        ExceptedCharType, StringLiteral<ExceptedCharType, N>>
+        :std::true_type{};
+}
+namespace impl
+{
+    // match unknown type
+    template<class ExceptedCharType, class T>
+    struct IsSpecificStringPointer :std::false_type {};
+
+    // match pointer with different CharType
+    template<class ExceptedCharType, class SuppliedCharType>
+    struct IsSpecificStringPointer<ExceptedCharType, SuppliedCharType*> :std::false_type {};
+
+    // excepted match
+    template<class ExceptedCharType>
+    struct IsSpecificStringPointer<ExceptedCharType, ExceptedCharType*>
+        :std::true_type {};
+
+    template<class ExceptedCharType>
+    struct IsSpecificStringPointer<ExceptedCharType, const ExceptedCharType*>
+        :std::true_type {};
+}
+
+// returns true if remove_cvref_t<T> is ExceptedCharType[]
+template<class ExceptedCharType, class T>
+using IsSpecificStringLiteral = impl::IsSpecificStringLiteral<ExceptedCharType, remove_cvref_t<T>>;
+
+// returns true if remove_cvref_t<T> is ExceptedCharType *
+template<class ExceptedCharType, class T>
+using IsSpecificStringPointer = impl::IsSpecificStringPointer<ExceptedCharType, remove_cvref_t<T>>;
+
+// returns true if decay_t<T> is ExceptedCharType * or ExceptedCharType[]
+template<class ExceptedCharType, class T>
+using IsSpecificString = std::conditional_t<
+    IsSpecificStringLiteral<ExceptedCharType, T>::value ||
+    IsSpecificStringPointer<ExceptedCharType, T>::value,
+    std::true_type, std::false_type>;
+
+//static_assert(IsSpecificStringLiteral<char, char[2]>::value);
+//static_assert(IsSpecificStringLiteral<char, const char[2]>::value);
+//static_assert(IsSpecificStringLiteral<char, const char(&)[2]>::value);
+//static_assert(!IsSpecificStringLiteral<char, int[2]>::value);
+//static_assert(!IsSpecificStringLiteral<char, char*>::value);
+//
+//using _pchar = char*;
+//static_assert(IsSpecificStringPointer<char, char*>::value);
+//static_assert(IsSpecificStringPointer<char, const char*>::value);
+//static_assert(IsSpecificStringPointer<char, _pchar &>::value);
+//static_assert(!IsSpecificStringPointer<char, int *>::value);
+//static_assert(!IsSpecificStringPointer<char, char[]>::value);
+
+
+RAPIDJSON_NAMESPACE_END


### PR DESCRIPTION
类似这样的表达式：
```val == "asdf"```
可以不使用StrLen，因为字符串长度在编译时就已经确定了。

在本次提交中：
  * 增加了一个```IsSpecificString```，用于判断参数是否为指定类型的字符串。
  * 将原来的operator == (const Ch *) 删掉了，因为这个函数不是template function，所以拥有最高的优先级。
  * 增加了一个template<class T> operator ==(const T), 并用enalbe_if于另一个类似的函数区分开来。

因为对rapidjson的TMP库不是很熟悉，所以不懂怎么用rapidjson的风格写出这些代码。  
管理大大如果有空，希望能稍微抽空帮忙修正一下代码。  