### PR TITLE
Fix memory issues

### DIFF
--- a/include/rapidjson/internal/regex.h
+++ b/include/rapidjson/internal/regex.h
@@ -78,7 +78,7 @@ static const SizeType kRegexInvalidState = ~SizeType(0);  //!< Represents an inv
 static const SizeType kRegexInvalidRange = ~SizeType(0);
 
 template <typename Encoding, typename Allocator>
-class GenericRegexSearch;
+class [[deprecated("missing handling of memory allocation errors")]] GenericRegexSearch;
 
 //! Regular expression engine with subset of ECMAscript grammar.
 /*!

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -125,12 +125,12 @@ RAPIDJSON_MULTILINEMACRO_END
 // Forward declarations
 
 template <typename ValueType, typename Allocator>
-class GenericSchemaDocument;
+class [[deprecated("missing handling of memory allocation errors")]] GenericSchemaDocument;
 
 namespace internal {
 
 template <typename SchemaDocumentType>
-class Schema;
+class [[deprecated("missing handling of memory allocation errors")]] Schema;
 
 ///////////////////////////////////////////////////////////////////////////////
 // ISchemaValidator


### PR DESCRIPTION
Fix memory issues in case Allocator::Malloc returned a `NULL` pointer or throwed an exception. Issues are:
- Segmentation fault when dereferencing a `NULL` pointer
- Memory leak due to an incorrect internal state (e.g. tokenCount_),
  when a custom Allocator throwed an exception during `Malloc`