### PR TITLE
Fix Conflict between rapidjson::GenericValue<···>::GetObject() vs GetObject macro in the windows headers (wingdi.h)

### DIFF
--- a/example/archiver/archiver.cpp
+++ b/example/archiver/archiver.cpp
@@ -9,8 +9,8 @@ using namespace rapidjson;
 
 struct JsonReaderStackItem {
     enum State {
-        BeforeStart,    //!< An object/array is in the stack but it is not yet called by StartObject()/StartArray().
-        Started,        //!< An object/array is called by StartObject()/StartArray().
+        BeforeStart,    //!< An object/array is in the stack but it is not yet called by StartObj()/StartArray().
+        Started,        //!< An object/array is called by StartObj()/StartArray().
         Closed          //!< An array is closed after read all element, but before EndArray().
     };
 
@@ -45,9 +45,9 @@ JsonReader::~JsonReader() {
 }
 
 // Archive concept
-JsonReader& JsonReader::StartObject() {
+JsonReader& JsonReader::StartObj() {
     if (!mError) {
-        if (CURRENT.IsObject() && TOP.state == JsonReaderStackItem::BeforeStart)
+        if (CURRENT.IsObj() && TOP.state == JsonReaderStackItem::BeforeStart)
             TOP.state = JsonReaderStackItem::Started;
         else
             mError = true;
@@ -55,9 +55,9 @@ JsonReader& JsonReader::StartObject() {
     return *this;
 }
 
-JsonReader& JsonReader::EndObject() {
+JsonReader& JsonReader::EndObj() {
     if (!mError) {
-        if (CURRENT.IsObject() && TOP.state == JsonReaderStackItem::Started)
+        if (CURRENT.IsObj() && TOP.state == JsonReaderStackItem::Started)
             Next();
         else
             mError = true;
@@ -67,7 +67,7 @@ JsonReader& JsonReader::EndObject() {
 
 JsonReader& JsonReader::Member(const char* name) {
     if (!mError) {
-        if (CURRENT.IsObject() && TOP.state == JsonReaderStackItem::Started) {
+        if (CURRENT.IsObj() && TOP.state == JsonReaderStackItem::Started) {
             Value::ConstMemberIterator memberItr = CURRENT.FindMember(name);
             if (memberItr != CURRENT.MemberEnd()) 
                 STACK->push(JsonReaderStackItem(&memberItr->value, JsonReaderStackItem::BeforeStart));
@@ -81,7 +81,7 @@ JsonReader& JsonReader::Member(const char* name) {
 }
 
 bool JsonReader::HasMember(const char* name) const {
-    if (!mError && CURRENT.IsObject() && TOP.state == JsonReaderStackItem::Started)
+    if (!mError && CURRENT.IsObj() && TOP.state == JsonReaderStackItem::Started)
         return CURRENT.HasMember(name);
     return false;
 }
@@ -227,13 +227,13 @@ const char* JsonWriter::GetString() const {
     return STREAM->GetString();
 }
 
-JsonWriter& JsonWriter::StartObject() {
-    WRITER->StartObject();
+JsonWriter& JsonWriter::StartObj() {
+    WRITER->StartObj();
     return *this;
 }
 
-JsonWriter& JsonWriter::EndObject() {
-    WRITER->EndObject();
+JsonWriter& JsonWriter::EndObj() {
+    WRITER->EndObj();
     return *this;
 }
 

--- a/example/archiver/archiver.h
+++ b/example/archiver/archiver.h
@@ -16,16 +16,16 @@ public:
     operator bool() const;
 
     /// Starts an object
-    Archiver& StartObject();
+    Archiver& StartObj();
     
-    /// After calling StartObject(), assign a member with a name
+    /// After calling StartObj(), assign a member with a name
     Archiver& Member(const char* name);
 
-    /// After calling StartObject(), check if a member presents
+    /// After calling StartObj(), check if a member presents
     bool HasMember(const char* name) const;
 
     /// Ends an object
-    Archiver& EndObject();
+    Archiver& EndObj();
 
     /// Starts an array
     /// \param size If Archiver::IsReader is true, the size of array is written.
@@ -69,10 +69,10 @@ public:
 
     operator bool() const { return !mError; }
 
-    JsonReader& StartObject();
+    JsonReader& StartObj();
     JsonReader& Member(const char* name);
     bool HasMember(const char* name) const;
-    JsonReader& EndObject();
+    JsonReader& EndObj();
 
     JsonReader& StartArray(size_t* size = 0);
     JsonReader& EndArray();
@@ -115,10 +115,10 @@ public:
 
     operator bool() const { return true; }
 
-    JsonWriter& StartObject();
+    JsonWriter& StartObj();
     JsonWriter& Member(const char* name);
     bool HasMember(const char* name) const;
-    JsonWriter& EndObject();
+    JsonWriter& EndObj();
 
     JsonWriter& StartArray(size_t* size = 0);
     JsonWriter& EndArray();

--- a/example/archiver/archivertest.cpp
+++ b/example/archiver/archivertest.cpp
@@ -19,12 +19,12 @@ struct Student {
 
 template <typename Archiver>
 Archiver& operator&(Archiver& ar, Student& s) {
-    ar.StartObject();
+    ar.StartObj();
     ar.Member("name") & s.name;
     ar.Member("age") & s.age;
     ar.Member("height") & s.height;
     ar.Member("canSwim") & s.canSwim;
-    return ar.EndObject();
+    return ar.EndObj();
 }
 
 std::ostream& operator<<(std::ostream& os, const Student& s) {
@@ -66,7 +66,7 @@ struct Group {
 
 template <typename Archiver>
 Archiver& operator&(Archiver& ar, Group& g) {
-    ar.StartObject();
+    ar.StartObj();
     
     ar.Member("groupName");
     ar & g.groupName;
@@ -80,7 +80,7 @@ Archiver& operator&(Archiver& ar, Group& g) {
         ar & g.students[i];
     ar.EndArray();
 
-    return ar.EndObject();
+    return ar.EndObj();
 }
 
 std::ostream& operator<<(std::ostream& os, const Group& g) {
@@ -228,7 +228,7 @@ private:
 template <typename Archiver>
 Archiver& operator&(Archiver& ar, Shape*& shape) {
     std::string type = ar.IsReader ? "" : shape->GetType();
-    ar.StartObject();
+    ar.StartObj();
     ar.Member("type") & type;
     if (type == "Circle") {
         if (ar.IsReader) shape = new Circle;
@@ -238,7 +238,7 @@ Archiver& operator&(Archiver& ar, Shape*& shape) {
         if (ar.IsReader) shape = new Box;
         ar & static_cast<Box&>(*shape);
     }
-    return ar.EndObject();
+    return ar.EndObj();
 }
 
 template <typename Archiver>

--- a/example/capitalize/capitalize.cpp
+++ b/example/capitalize/capitalize.cpp
@@ -31,9 +31,9 @@ struct CapitalizeFilter {
             buffer_.push_back(static_cast<char>(std::toupper(str[i])));
         return out_.String(&buffer_.front(), length, true); // true = output handler need to copy the string
     }
-    bool StartObject() { return out_.StartObject(); }
+    bool StartObj() { return out_.StartObj(); }
     bool Key(const char* str, SizeType length, bool copy) { return String(str, length, copy); }
-    bool EndObject(SizeType memberCount) { return out_.EndObject(memberCount); }
+    bool EndObj(SizeType memberCount) { return out_.EndObj(memberCount); }
     bool StartArray() { return out_.StartArray(); }
     bool EndArray(SizeType elementCount) { return out_.EndArray(elementCount); }
 

--- a/example/filterkey/filterkey.cpp
+++ b/example/filterkey/filterkey.cpp
@@ -33,14 +33,14 @@ public:
     bool RawNumber(const Ch* str, SizeType len, bool copy) { return filterValueDepth_ > 0 ? EndValue() : outputHandler_.RawNumber(str, len, copy) && EndValue(); }
     bool String   (const Ch* str, SizeType len, bool copy) { return filterValueDepth_ > 0 ? EndValue() : outputHandler_.String   (str, len, copy) && EndValue(); }
     
-    bool StartObject() { 
+    bool StartObj() { 
         if (filterValueDepth_ > 0) {
             filterValueDepth_++;
             return true;
         }
         else {
             filteredKeyCount_.push(0);
-            return outputHandler_.StartObject();
+            return outputHandler_.StartObj();
         }
     }
     
@@ -57,7 +57,7 @@ public:
         }
     }
 
-    bool EndObject(SizeType) {
+    bool EndObj(SizeType) {
         if (filterValueDepth_ > 0) {
             filterValueDepth_--;
             return EndValue();
@@ -66,7 +66,7 @@ public:
             // Use our own filtered memberCount
             SizeType memberCount = filteredKeyCount_.top();
             filteredKeyCount_.pop();
-            return outputHandler_.EndObject(memberCount) && EndValue();
+            return outputHandler_.EndObj(memberCount) && EndValue();
         }
     }
 

--- a/example/filterkeydom/filterkeydom.cpp
+++ b/example/filterkeydom/filterkeydom.cpp
@@ -34,14 +34,14 @@ public:
     bool RawNumber(const Ch* str, SizeType len, bool copy) { return filterValueDepth_ > 0 ? EndValue() : outputHandler_.RawNumber(str, len, copy) && EndValue(); }
     bool String   (const Ch* str, SizeType len, bool copy) { return filterValueDepth_ > 0 ? EndValue() : outputHandler_.String   (str, len, copy) && EndValue(); }
     
-    bool StartObject() { 
+    bool StartObj() { 
         if (filterValueDepth_ > 0) {
             filterValueDepth_++;
             return true;
         }
         else {
             filteredKeyCount_.push(0);
-            return outputHandler_.StartObject();
+            return outputHandler_.StartObj();
         }
     }
     
@@ -58,7 +58,7 @@ public:
         }
     }
 
-    bool EndObject(SizeType) {
+    bool EndObj(SizeType) {
         if (filterValueDepth_ > 0) {
             filterValueDepth_--;
             return EndValue();
@@ -67,7 +67,7 @@ public:
             // Use our own filtered memberCount
             SizeType memberCount = filteredKeyCount_.top();
             filteredKeyCount_.pop();
-            return outputHandler_.EndObject(memberCount) && EndValue();
+            return outputHandler_.EndObj(memberCount) && EndValue();
         }
     }
 

--- a/example/jsonx/jsonx.cpp
+++ b/example/jsonx/jsonx.cpp
@@ -71,7 +71,7 @@ public:
             WriteEndElement("string");
     }
 
-    bool StartObject() {
+    bool StartObj() {
         return WriteStartElement("object");
     }
 
@@ -84,7 +84,7 @@ public:
         return true;
     }
 
-    bool EndObject(SizeType) {
+    bool EndObj(SizeType) {
         return WriteEndElement("object");
     }
 

--- a/example/messagereader/messagereader.cpp
+++ b/example/messagereader/messagereader.cpp
@@ -24,12 +24,12 @@ RAPIDJSON_DIAG_OFF(switch-enum)
 
 struct MessageHandler
     : public BaseReaderHandler<UTF8<>, MessageHandler> {
-    MessageHandler() : messages_(), state_(kExpectObjectStart), name_() {}
+    MessageHandler() : messages_(), state_(kExpectObjStart), name_() {}
 
-    bool StartObject() {
+    bool StartObj() {
         switch (state_) {
-        case kExpectObjectStart:
-            state_ = kExpectNameOrObjectEnd;
+        case kExpectObjStart:
+            state_ = kExpectNameOrObjEnd;
             return true;
         default:
             return false;
@@ -38,27 +38,27 @@ struct MessageHandler
 
     bool String(const char* str, SizeType length, bool) {
         switch (state_) {
-        case kExpectNameOrObjectEnd:
+        case kExpectNameOrObjEnd:
             name_ = string(str, length);
             state_ = kExpectValue;
             return true;
         case kExpectValue:
             messages_.insert(MessageMap::value_type(name_, string(str, length)));
-            state_ = kExpectNameOrObjectEnd;
+            state_ = kExpectNameOrObjEnd;
             return true;
         default:
             return false;
         }
     }
 
-    bool EndObject(SizeType) { return state_ == kExpectNameOrObjectEnd; }
+    bool EndObj(SizeType) { return state_ == kExpectNameOrObjEnd; }
 
     bool Default() { return false; } // All other events are invalid.
 
     MessageMap messages_;
     enum State {
-        kExpectObjectStart,
-        kExpectNameOrObjectEnd,
+        kExpectObjStart,
+        kExpectNameOrObjEnd,
         kExpectValue
     }state_;
     std::string name_;

--- a/example/serialize/serialize.cpp
+++ b/example/serialize/serialize.cpp
@@ -49,7 +49,7 @@ public:
 
     template <typename Writer>
     void Serialize(Writer& writer) const {
-        writer.StartObject();
+        writer.StartObj();
         
         writer.String("school");
 #if RAPIDJSON_HAS_STDSTRING
@@ -61,7 +61,7 @@ public:
         writer.String("GPA");
         writer.Double(GPA_);
 
-        writer.EndObject();
+        writer.EndObj();
     }
 
 private:
@@ -85,7 +85,7 @@ public:
 
     template <typename Writer>
     void Serialize(Writer& writer) const {
-        writer.StartObject();
+        writer.StartObj();
 
         Person::Serialize(writer);
 
@@ -95,7 +95,7 @@ public:
         else
             writer.Null();
 
-        writer.EndObject();
+        writer.EndObj();
     }
 
 private:
@@ -126,7 +126,7 @@ public:
 
     template <typename Writer>
     void Serialize(Writer& writer) const {
-        writer.StartObject();
+        writer.StartObj();
 
         Person::Serialize(writer);
 
@@ -139,7 +139,7 @@ public:
             dependentItr->Serialize(writer);
         writer.EndArray();
 
-        writer.EndObject();
+        writer.EndObj();
     }
 
 private:

--- a/example/simplepullreader/simplepullreader.cpp
+++ b/example/simplepullreader/simplepullreader.cpp
@@ -27,9 +27,9 @@ struct MyHandler {
     bool Double(double d) { type = "Double:"; data = stringify(d); return true; }
     bool RawNumber(const char* str, SizeType length, bool) { type = "Number:"; data = std::string(str, length); return true; }
     bool String(const char* str, SizeType length, bool) { type = "String:"; data = std::string(str, length); return true; }
-    bool StartObject() { type = "StartObject"; data.clear(); return true; }
+    bool StartObj() { type = "StartObj"; data.clear(); return true; }
     bool Key(const char* str, SizeType length, bool) { type = "Key:"; data = std::string(str, length); return true; }
-    bool EndObject(SizeType memberCount) { type = "EndObject:"; data = stringify(memberCount); return true; }
+    bool EndObj(SizeType memberCount) { type = "EndObj:"; data = stringify(memberCount); return true; }
     bool StartArray() { type = "StartArray"; data.clear(); return true; }
     bool EndArray(SizeType elementCount) { type = "EndArray:"; data = stringify(elementCount); return true; }
 private:

--- a/example/simplereader/simplereader.cpp
+++ b/example/simplereader/simplereader.cpp
@@ -20,12 +20,12 @@ struct MyHandler {
         cout << "String(" << str << ", " << length << ", " << boolalpha << copy << ")" << endl;
         return true;
     }
-    bool StartObject() { cout << "StartObject()" << endl; return true; }
+    bool StartObj() { cout << "StartObj()" << endl; return true; }
     bool Key(const char* str, SizeType length, bool copy) {
         cout << "Key(" << str << ", " << length << ", " << boolalpha << copy << ")" << endl;
         return true;
     }
-    bool EndObject(SizeType memberCount) { cout << "EndObject(" << memberCount << ")" << endl; return true; }
+    bool EndObj(SizeType memberCount) { cout << "EndObj(" << memberCount << ")" << endl; return true; }
     bool StartArray() { cout << "StartArray()" << endl; return true; }
     bool EndArray(SizeType elementCount) { cout << "EndArray(" << elementCount << ")" << endl; return true; }
 };

--- a/example/simplewriter/simplewriter.cpp
+++ b/example/simplewriter/simplewriter.cpp
@@ -9,7 +9,7 @@ int main() {
     StringBuffer s;
     Writer<StringBuffer> writer(s);
     
-    writer.StartObject();               // Between StartObject()/EndObject(), 
+    writer.StartObj();               // Between StartObj()/EndObj(), 
     writer.Key("hello");                // output a key,
     writer.String("world");             // follow by a value.
     writer.Key("t");
@@ -27,7 +27,7 @@ int main() {
     for (unsigned i = 0; i < 4; i++)
         writer.Uint(i);                 // all values are elements of the array.
     writer.EndArray();
-    writer.EndObject();
+    writer.EndObj();
 
     // {"hello":"world","t":true,"f":false,"n":null,"i":123,"pi":3.1416,"a":[0,1,2,3]}
     cout << s.GetString() << endl;

--- a/example/sortkeys/sortkeys.cpp
+++ b/example/sortkeys/sortkeys.cpp
@@ -23,7 +23,7 @@ struct NameComparator {
 };
 
 int main() {
-    Document d(kObjectType);
+    Document d(kObjType);
     Document::AllocatorType &allocator = d.GetAllocator();
 
     d.AddMember("zeta", Value().SetBool(false), allocator);

--- a/example/tutorial/tutorial.cpp
+++ b/example/tutorial/tutorial.cpp
@@ -35,7 +35,7 @@ int main(int, char*[]) {
     // 2. Access values in document. 
 
     printf("\nAccess values in document:\n");
-    assert(document.IsObject());    // Document is a JSON value represents the root of DOM. Root can be either an object or array.
+    assert(document.IsObj());    // Document is a JSON value represents the root of DOM. Root can be either an object or array.
 
     assert(document.HasMember("hello"));
     assert(document["hello"].IsString());
@@ -81,7 +81,7 @@ int main(int, char*[]) {
     }
 
     // Iterating object members
-    static const char* kTypeNames[] = { "Null", "False", "True", "Object", "Array", "String", "Number" };
+    static const char* kTypeNames[] = { "Null", "False", "True", "Obj", "Array", "String", "Number" };
     for (Value::ConstMemberIterator itr = document.MemberBegin(); itr != document.MemberEnd(); ++itr)
         printf("Type of member %s is %s\n", itr->name.GetString(), kTypeNames[itr->value.GetType()]);
 

--- a/include/rapidjson/error/en.h
+++ b/include/rapidjson/error/en.h
@@ -42,9 +42,9 @@ inline const RAPIDJSON_ERROR_CHARTYPE* GetParseError_En(ParseErrorCode parseErro
     
         case kParseErrorValueInvalid:                   return RAPIDJSON_ERROR_STRING("Invalid value.");
     
-        case kParseErrorObjectMissName:                 return RAPIDJSON_ERROR_STRING("Missing a name for object member.");
-        case kParseErrorObjectMissColon:                return RAPIDJSON_ERROR_STRING("Missing a colon after a name of object member.");
-        case kParseErrorObjectMissCommaOrCurlyBracket:  return RAPIDJSON_ERROR_STRING("Missing a comma or '}' after an object member.");
+        case kParseErrorObjMissName:                 return RAPIDJSON_ERROR_STRING("Missing a name for object member.");
+        case kParseErrorObjMissColon:                return RAPIDJSON_ERROR_STRING("Missing a colon after a name of object member.");
+        case kParseErrorObjMissCommaOrCurlyBracket:  return RAPIDJSON_ERROR_STRING("Missing a comma or '}' after an object member.");
     
         case kParseErrorArrayMissCommaOrSquareBracket:  return RAPIDJSON_ERROR_STRING("Missing a comma or ']' after an array element.");
 

--- a/include/rapidjson/error/error.h
+++ b/include/rapidjson/error/error.h
@@ -69,9 +69,9 @@ enum ParseErrorCode {
 
     kParseErrorValueInvalid,                    //!< Invalid value.
 
-    kParseErrorObjectMissName,                  //!< Missing a name for object member.
-    kParseErrorObjectMissColon,                 //!< Missing a colon after a name of object member.
-    kParseErrorObjectMissCommaOrCurlyBracket,   //!< Missing a comma or '}' after an object member.
+    kParseErrorObjMissName,                  //!< Missing a name for object member.
+    kParseErrorObjMissColon,                 //!< Missing a colon after a name of object member.
+    kParseErrorObjMissCommaOrCurlyBracket,   //!< Missing a comma or '}' after an object member.
 
     kParseErrorArrayMissCommaOrSquareBracket,   //!< Missing a comma or ']' after an array element.
 

--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -48,7 +48,7 @@ enum PointerParseErrorCode {
 
 //! Represents a JSON Pointer. Use Pointer for UTF8 encoding and default allocator.
 /*!
-    This class implements RFC 6901 "JavaScript Object Notation (JSON) Pointer" 
+    This class implements RFC 6901 "JavaScript Obj Notation (JSON) Pointer" 
     (https://tools.ietf.org/html/rfc6901).
 
     A JSON pointer is for identifying a specific value in a JSON document
@@ -470,11 +470,11 @@ public:
             }
             else {
                 if (t->index == kPointerInvalidIndex) { // must be object name
-                    if (!v->IsObject())
-                        v->SetObject(); // Change to Object
+                    if (!v->IsObj())
+                        v->SetObj(); // Change to Obj
                 }
                 else { // object name or array index
-                    if (!v->IsArray() && !v->IsObject())
+                    if (!v->IsArray() && !v->IsObj())
                         v->SetArray(); // Change to Array
                 }
 
@@ -542,7 +542,7 @@ public:
         ValueType* v = &root;
         for (const Token *t = tokens_; t != tokens_ + tokenCount_; ++t) {
             switch (v->GetType()) {
-            case kObjectType:
+            case kObjType:
                 {
                     typename ValueType::MemberIterator m = v->FindMember(GenericValue<EncodingType>(GenericStringRef<Ch>(t->name, t->length)));
                     if (m == v->MemberEnd())
@@ -778,7 +778,7 @@ public:
         const Token* last = tokens_ + (tokenCount_ - 1);
         for (const Token *t = tokens_; t != last; ++t) {
             switch (v->GetType()) {
-            case kObjectType:
+            case kObjType:
                 {
                     typename ValueType::MemberIterator m = v->FindMember(GenericValue<EncodingType>(GenericStringRef<Ch>(t->name, t->length)));
                     if (m == v->MemberEnd())
@@ -797,7 +797,7 @@ public:
         }
 
         switch (v->GetType()) {
-        case kObjectType:
+        case kObjType:
             return v->EraseMember(GenericStringRef<Ch>(last->name, last->length));
         case kArrayType:
             if (last->index == kPointerInvalidIndex || last->index >= v->Size())

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -120,10 +120,10 @@ public:
     }
 #endif
 
-    bool StartObject() {
-        PrettyPrefix(kObjectType);
+    bool StartObj() {
+        PrettyPrefix(kObjType);
         new (Base::level_stack_.template Push<typename Base::Level>()) typename Base::Level(false);
-        return Base::WriteStartObject();
+        return Base::WriteStartObj();
     }
 
     bool Key(const Ch* str, SizeType length, bool copy = false) { return String(str, length, copy); }
@@ -134,11 +134,11 @@ public:
     }
 #endif
 	
-    bool EndObject(SizeType memberCount = 0) {
+    bool EndObj(SizeType memberCount = 0) {
         (void)memberCount;
-        RAPIDJSON_ASSERT(Base::level_stack_.GetSize() >= sizeof(typename Base::Level)); // not inside an Object
-        RAPIDJSON_ASSERT(!Base::level_stack_.template Top<typename Base::Level>()->inArray); // currently inside an Array, not Object
-        RAPIDJSON_ASSERT(0 == Base::level_stack_.template Top<typename Base::Level>()->valueCount % 2); // Object has a Key without a Value
+        RAPIDJSON_ASSERT(Base::level_stack_.GetSize() >= sizeof(typename Base::Level)); // not inside an Obj
+        RAPIDJSON_ASSERT(!Base::level_stack_.template Top<typename Base::Level>()->inArray); // currently inside an Array, not Obj
+        RAPIDJSON_ASSERT(0 == Base::level_stack_.template Top<typename Base::Level>()->valueCount % 2); // Obj has a Key without a Value
        
         bool empty = Base::level_stack_.template Pop<typename Base::Level>(1)->valueCount == 0;
 
@@ -146,7 +146,7 @@ public:
             Base::os_->Put('\n');
             WriteIndent();
         }
-        bool ret = Base::EndValue(Base::WriteEndObject());
+        bool ret = Base::EndValue(Base::WriteEndObj());
         (void)ret;
         RAPIDJSON_ASSERT(ret == true);
         if (Base::level_stack_.Empty()) // end of json text

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -681,7 +681,7 @@ enum Type {
     kNullType = 0,      //!< null
     kFalseType = 1,     //!< false
     kTrueType = 2,      //!< true
-    kObjectType = 3,    //!< object
+    kObjType = 3,    //!< object
     kArrayType = 4,     //!< array 
     kStringType = 5,    //!< string
     kNumberType = 6     //!< number

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -247,10 +247,10 @@ public:
         return true;
     }
 
-    bool StartObject() { return true; }
+    bool StartObj() { return true; }
     bool Key(const Ch* str, SizeType len, bool copy) { return String(str, len, copy); }
-    bool EndObject(SizeType memberCount) { 
-        uint64_t h = Hash(0, kObjectType);
+    bool EndObj(SizeType memberCount) { 
+        uint64_t h = Hash(0, kObjType);
         uint64_t* kv = stack_.template Pop<uint64_t>(memberCount * 2);
         for (SizeType i = 0; i < memberCount; i++)
             h ^= Hash(kv[i * 2], kv[i * 2 + 1]);  // Use xor to achieve member order insensitive
@@ -446,7 +446,7 @@ public:
         typedef typename ValueType::ConstValueIterator ConstValueIterator;
         typedef typename ValueType::ConstMemberIterator ConstMemberIterator;
 
-        if (!value.IsObject())
+        if (!value.IsObj())
             return;
 
         if (const ValueType* v = GetMember(value, GetTypeString())) {
@@ -483,7 +483,7 @@ public:
             validatorCount_++;
         }
 
-        // Object
+        // Obj
 
         const ValueType* properties = GetMember(value, GetPropertiesString());
         const ValueType* required = GetMember(value, GetRequiredString());
@@ -492,7 +492,7 @@ public:
             // Gather properties from properties/required/dependencies
             SValue allProperties(kArrayType);
 
-            if (properties && properties->IsObject())
+            if (properties && properties->IsObj())
                 for (ConstMemberIterator itr = properties->MemberBegin(); itr != properties->MemberEnd(); ++itr)
                     AddUniqueElement(allProperties, itr->name);
             
@@ -501,7 +501,7 @@ public:
                     if (itr->IsString())
                         AddUniqueElement(allProperties, *itr);
 
-            if (dependencies && dependencies->IsObject())
+            if (dependencies && dependencies->IsObj())
                 for (ConstMemberIterator itr = dependencies->MemberBegin(); itr != dependencies->MemberEnd(); ++itr) {
                     AddUniqueElement(allProperties, itr->name);
                     if (itr->value.IsArray())
@@ -521,7 +521,7 @@ public:
             }
         }
 
-        if (properties && properties->IsObject()) {
+        if (properties && properties->IsObj()) {
             PointerType q = p.Append(GetPropertiesString(), allocator_);
             for (ConstMemberIterator itr = properties->MemberBegin(); itr != properties->MemberEnd(); ++itr) {
                 SizeType index;
@@ -553,7 +553,7 @@ public:
                     }
                 }
 
-        if (dependencies && dependencies->IsObject()) {
+        if (dependencies && dependencies->IsObj()) {
             PointerType q = p.Append(GetDependenciesString(), allocator_);
             hasDependencies_ = true;
             for (ConstMemberIterator itr = dependencies->MemberBegin(); itr != dependencies->MemberEnd(); ++itr) {
@@ -568,7 +568,7 @@ public:
                                 properties_[sourceIndex].dependencies[targetIndex] = true;
                         }
                     }
-                    else if (itr->value.IsObject()) {
+                    else if (itr->value.IsObj()) {
                         hasSchemaDependencies_ = true;
                         schemaDocument->CreateSchema(&properties_[sourceIndex].dependenciesSchema, q.Append(itr->name, allocator_), itr->value, document);
                         properties_[sourceIndex].dependenciesValidatorIndex = validatorCount_;
@@ -581,7 +581,7 @@ public:
         if (const ValueType* v = GetMember(value, GetAdditionalPropertiesString())) {
             if (v->IsBool())
                 additionalProperties_ = v->GetBool();
-            else if (v->IsObject())
+            else if (v->IsObj())
                 schemaDocument->CreateSchema(&additionalPropertiesSchema_, p.Append(GetAdditionalPropertiesString(), allocator_), *v, document);
         }
 
@@ -591,7 +591,7 @@ public:
         // Array
         if (const ValueType* v = GetMember(value, GetItemsString())) {
             PointerType q = p.Append(GetItemsString(), allocator_);
-            if (v->IsObject()) // List validation
+            if (v->IsObj()) // List validation
                 schemaDocument->CreateSchema(&itemsList_, q, *v, document);
             else if (v->IsArray()) { // Tuple validation
                 itemsTuple_ = static_cast<const Schema**>(allocator_->Malloc(sizeof(const Schema*) * v->Size()));
@@ -607,7 +607,7 @@ public:
         if (const ValueType* v = GetMember(value, GetAdditionalItemsString())) {
             if (v->IsBool())
                 additionalItems_ = v->GetBool();
-            else if (v->IsObject())
+            else if (v->IsObj())
                 schemaDocument->CreateSchema(&additionalItemsSchema_, p.Append(GetAdditionalItemsString(), allocator_), *v, document);
         }
 
@@ -867,9 +867,9 @@ public:
         return CreateParallelValidator(context);
     }
 
-    bool StartObject(Context& context) const {
-        if (!(type_ & (1 << kObjectSchemaType))) {
-            DisallowedType(context, GetObjectString());
+    bool StartObj(Context& context) const {
+        if (!(type_ & (1 << kObjSchemaType))) {
+            DisallowedType(context, GetObjString());
             RAPIDJSON_INVALID_KEYWORD_RETURN(GetTypeString());
         }
 
@@ -937,7 +937,7 @@ public:
         return true;
     }
 
-    bool EndObject(Context& context, SizeType memberCount) const {
+    bool EndObj(Context& context, SizeType memberCount) const {
         if (hasRequired_) {
             context.error_handler.StartMissingProperties();
             for (SizeType index = 0; index < propertyCount_; index++)
@@ -1022,7 +1022,7 @@ public:
 
     RAPIDJSON_STRING_(Null, 'n', 'u', 'l', 'l')
     RAPIDJSON_STRING_(Boolean, 'b', 'o', 'o', 'l', 'e', 'a', 'n')
-    RAPIDJSON_STRING_(Object, 'o', 'b', 'j', 'e', 'c', 't')
+    RAPIDJSON_STRING_(Obj, 'o', 'b', 'j', 'e', 'c', 't')
     RAPIDJSON_STRING_(Array, 'a', 'r', 'r', 'a', 'y')
     RAPIDJSON_STRING_(String, 's', 't', 'r', 'i', 'n', 'g')
     RAPIDJSON_STRING_(Number, 'n', 'u', 'm', 'b', 'e', 'r')
@@ -1061,7 +1061,7 @@ private:
     enum SchemaValueType {
         kNullSchemaType,
         kBooleanSchemaType,
-        kObjectSchemaType,
+        kObjSchemaType,
         kArraySchemaType,
         kStringSchemaType,
         kNumberSchemaType,
@@ -1174,7 +1174,7 @@ private:
     void AddType(const ValueType& type) {
         if      (type == GetNullString()   ) type_ |= 1 << kNullSchemaType;
         else if (type == GetBooleanString()) type_ |= 1 << kBooleanSchemaType;
-        else if (type == GetObjectString() ) type_ |= 1 << kObjectSchemaType;
+        else if (type == GetObjString() ) type_ |= 1 << kObjSchemaType;
         else if (type == GetArrayString()  ) type_ |= 1 << kArraySchemaType;
         else if (type == GetStringString() ) type_ |= 1 << kStringSchemaType;
         else if (type == GetIntegerString()) type_ |= 1 << kIntegerSchemaType;
@@ -1360,7 +1360,7 @@ private:
 
         if (type_ & (1 << kNullSchemaType)) eh.AddExpectedType(GetNullString());
         if (type_ & (1 << kBooleanSchemaType)) eh.AddExpectedType(GetBooleanString());
-        if (type_ & (1 << kObjectSchemaType)) eh.AddExpectedType(GetObjectString());
+        if (type_ & (1 << kObjSchemaType)) eh.AddExpectedType(GetObjString());
         if (type_ & (1 << kArraySchemaType)) eh.AddExpectedType(GetArrayString());
         if (type_ & (1 << kStringSchemaType)) eh.AddExpectedType(GetStringString());
 
@@ -1539,7 +1539,7 @@ public:
         uri_.SetString(uri ? uri : noUri, uriLength, *allocator_);
 
         typeless_ = static_cast<SchemaType*>(allocator_->Malloc(sizeof(SchemaType)));
-        new (typeless_) SchemaType(this, PointerType(), ValueType(kObjectType).Move(), ValueType(kObjectType).Move(), allocator_);
+        new (typeless_) SchemaType(this, PointerType(), ValueType(kObjType).Move(), ValueType(kObjType).Move(), allocator_);
 
         // Generate root schema, it will call CreateSchema() to create sub-schemas,
         // And call AddRefSchema() if there are $ref.
@@ -1635,7 +1635,7 @@ private:
         if (schema)
             *schema = typeless_;
 
-        if (v.GetType() == kObjectType) {
+        if (v.GetType() == kObjType) {
             const SchemaType* s = GetSchema(pointer);
             if (!s)
                 CreateSchema(schema, pointer, v, document);
@@ -1650,7 +1650,7 @@ private:
 
     void CreateSchema(const SchemaType** schema, const PointerType& pointer, const ValueType& v, const ValueType& document) {
         RAPIDJSON_ASSERT(pointer.IsValid());
-        if (v.IsObject()) {
+        if (v.IsObj()) {
             if (!HandleRefSchema(pointer, schema, v, document)) {
                 SchemaType* s = new (allocator_->Malloc(sizeof(SchemaType))) SchemaType(this, pointer, v, document, allocator_);
                 new (schemaMap_.template Push<SchemaEntry>()) SchemaEntry(pointer, s, true, allocator_);
@@ -1794,7 +1794,7 @@ public:
         schemaStack_(allocator, schemaStackCapacity),
         documentStack_(allocator, documentStackCapacity),
         outputHandler_(0),
-        error_(kObjectType),
+        error_(kObjType),
         currentError_(),
         missingDependents_(),
         valid_(true)
@@ -1825,7 +1825,7 @@ public:
         schemaStack_(allocator, schemaStackCapacity),
         documentStack_(allocator, documentStackCapacity),
         outputHandler_(&outputHandler),
-        error_(kObjectType),
+        error_(kObjType),
         currentError_(),
         missingDependents_(),
         valid_(true)
@@ -1846,7 +1846,7 @@ public:
         while (!schemaStack_.Empty())
             PopSchema();
         documentStack_.Clear();
-        error_.SetObject();
+        error_.SetObj();
         currentError_.SetNull();
         missingDependents_.SetNull();
         valid_ = true;
@@ -1923,13 +1923,13 @@ public:
             ValueType(str, length, GetStateAllocator()).Move(), SValue(expected).Move());
     }
     void DoesNotMatch(const Ch* str, SizeType length) {
-        currentError_.SetObject();
+        currentError_.SetObj();
         currentError_.AddMember(GetActualString(), ValueType(str, length, GetStateAllocator()).Move(), GetStateAllocator());
         AddCurrentError(SchemaType::GetPatternString());
     }
 
     void DisallowedItem(SizeType index) {
-        currentError_.SetObject();
+        currentError_.SetObj();
         currentError_.AddMember(GetDisallowedString(), ValueType(index).Move(), GetStateAllocator());
         AddCurrentError(SchemaType::GetAdditionalItemsString(), true);
     }
@@ -1945,7 +1945,7 @@ public:
         ValueType duplicates(kArrayType);
         duplicates.PushBack(index1, GetStateAllocator());
         duplicates.PushBack(index2, GetStateAllocator());
-        currentError_.SetObject();
+        currentError_.SetObj();
         currentError_.AddMember(GetDuplicatesString(), duplicates, GetStateAllocator());
         AddCurrentError(SchemaType::GetUniqueItemsString(), true);
     }
@@ -1967,7 +1967,7 @@ public:
     bool EndMissingProperties() {
         if (currentError_.Empty())
             return false;
-        ValueType error(kObjectType);
+        ValueType error(kObjType);
         error.AddMember(GetMissingString(), currentError_, GetStateAllocator());
         currentError_ = error;
         AddCurrentError(SchemaType::GetRequiredString());
@@ -1978,13 +1978,13 @@ public:
             MergeError(static_cast<GenericSchemaValidator*>(subvalidators[i])->GetError());
     }
     void DisallowedProperty(const Ch* name, SizeType length) {
-        currentError_.SetObject();
+        currentError_.SetObj();
         currentError_.AddMember(GetDisallowedString(), ValueType(name, length, GetStateAllocator()).Move(), GetStateAllocator());
         AddCurrentError(SchemaType::GetAdditionalPropertiesString(), true);
     }
 
     void StartDependencyErrors() {
-        currentError_.SetObject();
+        currentError_.SetObj();
     }
     void StartMissingDependentProperties() {
         missingDependents_.SetArray();
@@ -2002,9 +2002,9 @@ public:
             static_cast<GenericSchemaValidator*>(subvalidator)->GetError(), GetStateAllocator());
     }
     bool EndDependencyErrors() {
-        if (currentError_.ObjectEmpty())
+        if (currentError_.ObjEmpty())
             return false;
-        ValueType error(kObjectType);
+        ValueType error(kObjType);
         error.AddMember(GetErrorsString(), currentError_, GetStateAllocator());
         currentError_ = error;
         AddCurrentError(SchemaType::GetDependenciesString());
@@ -2012,7 +2012,7 @@ public:
     }
 
     void DisallowedValue() {
-        currentError_.SetObject();
+        currentError_.SetObj();
         AddCurrentError(SchemaType::GetEnumString());
     }
     void StartDisallowedType() {
@@ -2022,7 +2022,7 @@ public:
         currentError_.PushBack(ValueType(expectedType, GetStateAllocator()).Move(), GetStateAllocator());
     }
     void EndDisallowedType(const typename SchemaType::ValueType& actualType) {
-        ValueType error(kObjectType);
+        ValueType error(kObjType);
         error.AddMember(GetExpectedString(), currentError_, GetStateAllocator());
         error.AddMember(GetActualString(), ValueType(actualType, GetStateAllocator()).Move(), GetStateAllocator());
         currentError_ = error;
@@ -2040,7 +2040,7 @@ public:
         AddErrorArray(SchemaType::GetOneOfString(), subvalidators, count);
     }
     void Disallowed() {
-        currentError_.SetObject();
+        currentError_.SetObj();
         AddCurrentError(SchemaType::GetNotString());
     }
 
@@ -2112,10 +2112,10 @@ RAPIDJSON_MULTILINEMACRO_END
     bool String(const Ch* str, SizeType length, bool copy)
                                     { RAPIDJSON_SCHEMA_HANDLE_VALUE_(String, (CurrentContext(), str, length, copy), (str, length, copy)); }
 
-    bool StartObject() {
-        RAPIDJSON_SCHEMA_HANDLE_BEGIN_(StartObject, (CurrentContext()));
-        RAPIDJSON_SCHEMA_HANDLE_PARALLEL_(StartObject, ());
-        return valid_ = !outputHandler_ || outputHandler_->StartObject();
+    bool StartObj() {
+        RAPIDJSON_SCHEMA_HANDLE_BEGIN_(StartObj, (CurrentContext()));
+        RAPIDJSON_SCHEMA_HANDLE_PARALLEL_(StartObj, ());
+        return valid_ = !outputHandler_ || outputHandler_->StartObj();
     }
     
     bool Key(const Ch* str, SizeType len, bool copy) {
@@ -2126,11 +2126,11 @@ RAPIDJSON_MULTILINEMACRO_END
         return valid_ = !outputHandler_ || outputHandler_->Key(str, len, copy);
     }
     
-    bool EndObject(SizeType memberCount) { 
+    bool EndObj(SizeType memberCount) { 
         if (!valid_) return false;
-        RAPIDJSON_SCHEMA_HANDLE_PARALLEL_(EndObject, (memberCount));
-        if (!CurrentSchema().EndObject(CurrentContext(), memberCount)) return valid_ = false;
-        RAPIDJSON_SCHEMA_HANDLE_END_(EndObject, (memberCount));
+        RAPIDJSON_SCHEMA_HANDLE_PARALLEL_(EndObj, (memberCount));
+        if (!CurrentSchema().EndObj(CurrentContext(), memberCount)) return valid_ = false;
+        RAPIDJSON_SCHEMA_HANDLE_END_(EndObj, (memberCount));
     }
 
     bool StartArray() {
@@ -2211,7 +2211,7 @@ private:
         schemaStack_(allocator, schemaStackCapacity),
         documentStack_(allocator, documentStackCapacity),
         outputHandler_(0),
-        error_(kObjectType),
+        error_(kObjType),
         currentError_(),
         missingDependents_(),
         valid_(true)
@@ -2351,7 +2351,7 @@ private:
         if (member == error_.MemberEnd())
             error_.AddMember(keyword, error, GetStateAllocator());
         else {
-            if (member->value.IsObject()) {
+            if (member->value.IsObj()) {
                 ValueType errors(kArrayType);
                 errors.PushBack(member->value, GetStateAllocator());
                 member->value = errors;
@@ -2373,7 +2373,7 @@ private:
 
     void AddNumberError(const typename SchemaType::ValueType& keyword, ValueType& actual, const SValue& expected,
         const typename SchemaType::ValueType& (*exclusive)() = 0) {
-        currentError_.SetObject();
+        currentError_.SetObj();
         currentError_.AddMember(GetActualString(), actual, GetStateAllocator());
         currentError_.AddMember(GetExpectedString(), ValueType(expected, GetStateAllocator()).Move(), GetStateAllocator());
         if (exclusive)
@@ -2386,7 +2386,7 @@ private:
         ValueType errors(kArrayType);
         for (SizeType i = 0; i < count; ++i)
             errors.PushBack(static_cast<GenericSchemaValidator*>(subvalidators[i])->GetError(), GetStateAllocator());
-        currentError_.SetObject();
+        currentError_.SetObj();
         currentError_.AddMember(GetErrorsString(), errors, GetStateAllocator());
         AddCurrentError(keyword);
     }
@@ -2445,7 +2445,7 @@ public:
         \param is Input stream.
         \param sd Schema document.
     */
-    SchemaValidatingReader(InputStream& is, const SchemaDocumentType& sd) : is_(is), sd_(sd), invalidSchemaKeyword_(), error_(kObjectType), isValid_(true) {}
+    SchemaValidatingReader(InputStream& is, const SchemaDocumentType& sd) : is_(is), sd_(sd), invalidSchemaKeyword_(), error_(kObjType), isValid_(true) {}
 
     template <typename Handler>
     bool operator()(Handler& handler) {
@@ -2458,7 +2458,7 @@ public:
             invalidSchemaPointer_ = PointerType();
             invalidSchemaKeyword_ = 0;
             invalidDocumentPointer_ = PointerType();
-            error_.SetObject();
+            error_.SetObj();
         }
         else {
             invalidSchemaPointer_ = validator.GetInvalidSchemaPointer();

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -121,14 +121,14 @@ public:
         \param os New output stream.
         \code
         Writer<OutputStream> writer(os1);
-        writer.StartObject();
+        writer.StartObj();
         // ...
-        writer.EndObject();
+        writer.EndObj();
 
         writer.Reset(os2);
-        writer.StartObject();
+        writer.StartObj();
         // ...
-        writer.EndObject();
+        writer.EndObj();
         \endcode
     */
     void Reset(OutputStream& os) {
@@ -213,10 +213,10 @@ public:
     }
 #endif
 
-    bool StartObject() {
-        Prefix(kObjectType);
+    bool StartObj() {
+        Prefix(kObjType);
         new (level_stack_.template Push<Level>()) Level(false);
-        return WriteStartObject();
+        return WriteStartObj();
     }
 
     bool Key(const Ch* str, SizeType length, bool copy = false) { return String(str, length, copy); }
@@ -228,13 +228,13 @@ public:
     }
 #endif
 
-    bool EndObject(SizeType memberCount = 0) {
+    bool EndObj(SizeType memberCount = 0) {
         (void)memberCount;
-        RAPIDJSON_ASSERT(level_stack_.GetSize() >= sizeof(Level)); // not inside an Object
-        RAPIDJSON_ASSERT(!level_stack_.template Top<Level>()->inArray); // currently inside an Array, not Object
-        RAPIDJSON_ASSERT(0 == level_stack_.template Top<Level>()->valueCount % 2); // Object has a Key without a Value
+        RAPIDJSON_ASSERT(level_stack_.GetSize() >= sizeof(Level)); // not inside an Obj
+        RAPIDJSON_ASSERT(!level_stack_.template Top<Level>()->inArray); // currently inside an Array, not Obj
+        RAPIDJSON_ASSERT(0 == level_stack_.template Top<Level>()->valueCount % 2); // Obj has a Key without a Value
         level_stack_.template Pop<Level>(1);
-        return EndValue(WriteEndObject());
+        return EndValue(WriteEndObj());
     }
 
     bool StartArray() {
@@ -452,8 +452,8 @@ protected:
         return RAPIDJSON_LIKELY(is.Tell() < length);
     }
 
-    bool WriteStartObject() { os_->Put('{'); return true; }
-    bool WriteEndObject()   { os_->Put('}'); return true; }
+    bool WriteStartObj() { os_->Put('{'); return true; }
+    bool WriteEndObj()   { os_->Put('}'); return true; }
     bool WriteStartArray()  { os_->Put('['); return true; }
     bool WriteEndArray()    { os_->Put(']'); return true; }
 

--- a/test/perftest/platformtest.cpp
+++ b/test/perftest/platformtest.cpp
@@ -137,13 +137,13 @@ TEST_F(Platform, MapViewOfFile) {
     for (int i = 0; i < kTrialCount; i++) {
         HANDLE file = CreateFile(filename_, GENERIC_READ, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
         ASSERT_NE(INVALID_HANDLE_VALUE, file);
-        HANDLE mapObject = CreateFileMapping(file, NULL, PAGE_READONLY, 0, length_, NULL);
-        ASSERT_NE(INVALID_HANDLE_VALUE, mapObject);
-        void *p = MapViewOfFile(mapObject, FILE_MAP_READ, 0, 0, length_);
+        HANDLE mapObj = CreateFileMapping(file, NULL, PAGE_READONLY, 0, length_, NULL);
+        ASSERT_NE(INVALID_HANDLE_VALUE, mapObj);
+        void *p = MapViewOfFile(mapObj, FILE_MAP_READ, 0, 0, length_);
         ASSERT_TRUE(p != NULL);
         EXPECT_EQ(checkSum_, CheckSum());
         ASSERT_TRUE(UnmapViewOfFile(p) == TRUE);
-        ASSERT_TRUE(CloseHandle(mapObject) == TRUE);
+        ASSERT_TRUE(CloseHandle(mapObj) == TRUE);
         ASSERT_TRUE(CloseHandle(file) == TRUE);
     }
 }

--- a/test/perftest/rapidjsontest.cpp
+++ b/test/perftest/rapidjsontest.cpp
@@ -200,7 +200,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseInsitu_MemoryPoolAllocator)) {
         memcpy(temp_, json_, length_ + 1);
         Document doc;
         doc.ParseInsitu(temp_);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 
@@ -209,7 +209,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseIterativeInsitu_MemoryPoolAllocator))
         memcpy(temp_, json_, length_ + 1);
         Document doc;
         doc.ParseInsitu<kParseIterativeFlag>(temp_);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 
@@ -217,7 +217,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParse_MemoryPoolAllocator)) {
     for (size_t i = 0; i < kTrialCount; i++) {
         Document doc;
         doc.Parse(json_);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 
@@ -225,7 +225,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseLength_MemoryPoolAllocator)) {
     for (size_t i = 0; i < kTrialCount; i++) {
         Document doc;
         doc.Parse(json_, length_);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 
@@ -235,7 +235,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseStdString_MemoryPoolAllocator)) {
     for (size_t i = 0; i < kTrialCount; i++) {
         Document doc;
         doc.Parse(s);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 #endif
@@ -244,7 +244,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseIterative_MemoryPoolAllocator)) {
     for (size_t i = 0; i < kTrialCount; i++) {
         Document doc;
         doc.Parse<kParseIterativeFlag>(json_);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 
@@ -253,7 +253,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParse_CrtAllocator)) {
         memcpy(temp_, json_, length_ + 1);
         GenericDocument<UTF8<>, CrtAllocator> doc;
         doc.Parse(temp_);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 
@@ -263,7 +263,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseEncodedInputStream_MemoryStream)) {
         EncodedInputStream<UTF8<>, MemoryStream> is(ms);
         Document doc;
         doc.ParseStream<0, UTF8<> >(is);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 
@@ -273,7 +273,7 @@ TEST_F(RapidJson, SIMD_SUFFIX(DocumentParseAutoUTFInputStream_MemoryStream)) {
         AutoUTFInputStream<unsigned, MemoryStream> is(ms);
         Document doc;
         doc.ParseStream<0, AutoUTF<unsigned> >(is);
-        ASSERT_TRUE(doc.IsObject());
+        ASSERT_TRUE(doc.IsObj());
     }
 }
 
@@ -281,7 +281,7 @@ template<typename T>
 size_t Traverse(const T& value) {
     size_t count = 1;
     switch(value.GetType()) {
-        case kObjectType:
+        case kObjType:
             for (typename T::ConstMemberIterator itr = value.MemberBegin(); itr != value.MemberEnd(); ++itr) {
                 count++;    // name
                 count += Traverse(itr->value);
@@ -317,7 +317,7 @@ RAPIDJSON_DIAG_OFF(effc++)
 struct ValueCounter : public BaseReaderHandler<> {
     ValueCounter() : count_(1) {}   // root
 
-    bool EndObject(SizeType memberCount) { count_ += memberCount * 2; return true; }
+    bool EndObj(SizeType memberCount) { count_ += memberCount * 2; return true; }
     bool EndArray(SizeType elementCount) { count_ += elementCount; return true; }
 
     SizeType count_;

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -38,7 +38,7 @@ void ParseCheck(DocumentType& doc) {
         printf("Error: %d at %zu\n", static_cast<int>(doc.GetParseError()), doc.GetErrorOffset());
     EXPECT_TRUE(static_cast<ParseResult>(doc));
 
-    EXPECT_TRUE(doc.IsObject());
+    EXPECT_TRUE(doc.IsObj());
 
     EXPECT_TRUE(doc.HasMember("hello"));
     const ValueType& hello = doc["hello"];
@@ -149,7 +149,7 @@ TEST(Document, UnchangedOnParseError) {
     EXPECT_EQ(err.Code(), noError);
     EXPECT_EQ(err.Code(), doc.GetParseError());
     EXPECT_EQ(err.Offset(), doc.GetErrorOffset());
-    EXPECT_TRUE(doc.IsObject());
+    EXPECT_TRUE(doc.IsObj());
     EXPECT_EQ(doc.MemberCount(), 0u);
 }
 
@@ -297,19 +297,19 @@ TEST(Document, Swap) {
     d1.SetArray().PushBack(1, a).PushBack(2, a);
 
     Value o;
-    o.SetObject().AddMember("a", 1, a);
+    o.SetObj().AddMember("a", 1, a);
 
     // Swap between Document and Value
     d1.Swap(o);
-    EXPECT_TRUE(d1.IsObject());
+    EXPECT_TRUE(d1.IsObj());
     EXPECT_TRUE(o.IsArray());
 
     d1.Swap(o);
     EXPECT_TRUE(d1.IsArray());
-    EXPECT_TRUE(o.IsObject());
+    EXPECT_TRUE(o.IsObj());
 
     o.Swap(d1);
-    EXPECT_TRUE(d1.IsObject());
+    EXPECT_TRUE(d1.IsObj());
     EXPECT_TRUE(o.IsArray());
 
     // Swap between Document and Document
@@ -317,7 +317,7 @@ TEST(Document, Swap) {
     d2.SetArray().PushBack(3, a);
     d1.Swap(d2);
     EXPECT_TRUE(d1.IsArray());
-    EXPECT_TRUE(d2.IsObject());
+    EXPECT_TRUE(d2.IsObj());
     EXPECT_EQ(&d2.GetAllocator(), &a);
 
     // reset value
@@ -387,7 +387,7 @@ TEST(Document, UserBuffer) {
 // Issue 226: Value of string type should not point to NULL
 TEST(Document, AssertAcceptInvalidNameType) {
     Document doc;
-    doc.SetObject();
+    doc.SetObj();
     doc.AddMember("a", 0, doc.GetAllocator());
     doc.FindMember("a")->name.SetNull(); // Change name to non-string type.
 
@@ -403,7 +403,7 @@ TEST(Document, UTF16_Document) {
 
     ASSERT_TRUE(json.IsArray());
     GenericValue< UTF16<> >& v = json[0];
-    ASSERT_TRUE(v.IsObject());
+    ASSERT_TRUE(v.IsObj());
 
     GenericValue< UTF16<> >& s = v[L"created_at"];
     ASSERT_TRUE(s.IsString());
@@ -483,13 +483,13 @@ TYPED_TEST(DocumentMove, MoveConstructor) {
 
     b.Parse("{\"Foo\": \"Bar\", \"Baz\": 42}");
     EXPECT_FALSE(b.HasParseError());
-    EXPECT_TRUE(b.IsObject());
+    EXPECT_TRUE(b.IsObj());
     EXPECT_EQ(2u, b.MemberCount());
 
     // Document c = a; // does not compile (!is_copy_constructible)
     D c = std::move(b);
     EXPECT_TRUE(b.IsNull());
-    EXPECT_TRUE(c.IsObject());
+    EXPECT_TRUE(c.IsObj());
     EXPECT_EQ(2u, c.MemberCount());
     EXPECT_THROW(b.GetAllocator(), AssertException);
     EXPECT_EQ(&c.GetAllocator(), &allocator);
@@ -581,14 +581,14 @@ TYPED_TEST(DocumentMove, MoveAssignment) {
 
     b.Parse("{\"Foo\": \"Bar\", \"Baz\": 42}");
     EXPECT_FALSE(b.HasParseError());
-    EXPECT_TRUE(b.IsObject());
+    EXPECT_TRUE(b.IsObj());
     EXPECT_EQ(2u, b.MemberCount());
 
     // Document c; c = a; // does not compile (see static_assert)
     D c;
     c = std::move(b);
     EXPECT_TRUE(b.IsNull());
-    EXPECT_TRUE(c.IsObject());
+    EXPECT_TRUE(c.IsObj());
     EXPECT_EQ(2u, c.MemberCount());
     EXPECT_THROW(b.GetAllocator(), AssertException);
     EXPECT_EQ(&c.GetAllocator(), &allocator);

--- a/test/unittest/istreamwrappertest.cpp
+++ b/test/unittest/istreamwrappertest.cpp
@@ -128,7 +128,7 @@ TEST(IStreamWrapper, ifstream) {
     EncodedInputStream<UTF8<>, IStreamWrapper> eis(isw);
     Document d;
     EXPECT_TRUE(!d.ParseStream(eis).HasParseError());
-    EXPECT_TRUE(d.IsObject());
+    EXPECT_TRUE(d.IsObj());
     EXPECT_EQ(5u, d.MemberCount());
 }
 
@@ -139,7 +139,7 @@ TEST(IStreamWrapper, fstream) {
     EncodedInputStream<UTF8<>, IStreamWrapper> eis(isw);
     Document d;
     EXPECT_TRUE(!d.ParseStream(eis).HasParseError());
-    EXPECT_TRUE(d.IsObject());
+    EXPECT_TRUE(d.IsObj());
     EXPECT_EQ(5u, d.MemberCount());
 }
 
@@ -157,7 +157,7 @@ TEST(IStreamWrapper, wifstream) {
     GenericDocument<UTF16<> > d;
     d.ParseStream<kParseDefaultFlags, UTF16<>, WIStreamWrapper>(isw);
     EXPECT_TRUE(!d.HasParseError());
-    EXPECT_TRUE(d.IsObject());
+    EXPECT_TRUE(d.IsObj());
     EXPECT_EQ(5, d.MemberCount());
 }
 
@@ -170,7 +170,7 @@ TEST(IStreamWrapper, wfstream) {
     GenericDocument<UTF16<> > d;
     d.ParseStream<kParseDefaultFlags, UTF16<>, WIStreamWrapper>(isw);
     EXPECT_TRUE(!d.HasParseError());
-    EXPECT_TRUE(d.IsObject());
+    EXPECT_TRUE(d.IsObj());
     EXPECT_EQ(5, d.MemberCount());
 }
 

--- a/test/unittest/jsoncheckertest.cpp
+++ b/test/unittest/jsoncheckertest.cpp
@@ -58,9 +58,9 @@ struct NoOpHandler {
     bool Double(double) { return true; }
     bool RawNumber(const char*, SizeType, bool) { return true; }
     bool String(const char*, SizeType, bool) { return true; }
-    bool StartObject() { return true; }
+    bool StartObj() { return true; }
     bool Key(const char*, SizeType, bool) { return true; }
-    bool EndObject(SizeType) { return true; }
+    bool EndObj(SizeType) { return true; }
     bool StartArray() { return true; }
     bool EndArray(SizeType) { return true; }
 };

--- a/test/unittest/pointertest.cpp
+++ b/test/unittest/pointertest.cpp
@@ -1529,17 +1529,17 @@ TEST(Pointer, Ambiguity) {
     }
 }
 
-TEST(Pointer, ResolveOnObject) {
+TEST(Pointer, ResolveOnObj) {
     Document d;
     EXPECT_FALSE(d.Parse("{\"a\": 123}").HasParseError());
 
     {
-        Value::ConstObject o = static_cast<const Document&>(d).GetObject();
+        Value::ConstObj o = static_cast<const Document&>(d).GetObj();
         EXPECT_EQ(123, Pointer("/a").Get(o)->GetInt());
     }
 
     {
-        Value::Object o = d.GetObject();
+        Value::Obj o = d.GetObj();
         Pointer("/a").Set(o, 456, d.GetAllocator());
         EXPECT_EQ(456, Pointer("/a").Get(o)->GetInt());
     }

--- a/test/unittest/prettywritertest.cpp
+++ b/test/unittest/prettywritertest.cpp
@@ -192,13 +192,13 @@ TEST(PrettyWriter, FileWriteStream) {
 TEST(PrettyWriter, RawValue) {
     StringBuffer buffer;
     PrettyWriter<StringBuffer> writer(buffer);
-    writer.StartObject();
+    writer.StartObj();
     writer.Key("a");
     writer.Int(1);
     writer.Key("raw");
     const char json[] = "[\"Hello\\nWorld\", 123.456]";
     writer.RawValue(json, strlen(json), kArrayType);
-    writer.EndObject();
+    writer.EndObj();
     EXPECT_TRUE(writer.IsComplete());
     EXPECT_STREQ(
         "{\n"
@@ -213,7 +213,7 @@ TEST(PrettyWriter, InvalidEventSequence) {
     {
         StringBuffer buffer;
         PrettyWriter<StringBuffer> writer(buffer);
-        writer.StartObject();
+        writer.StartObj();
         EXPECT_THROW(writer.EndArray(), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
@@ -223,7 +223,7 @@ TEST(PrettyWriter, InvalidEventSequence) {
         StringBuffer buffer;
         PrettyWriter<StringBuffer> writer(buffer);
         writer.StartArray();
-        EXPECT_THROW(writer.EndObject(), AssertException);
+        EXPECT_THROW(writer.EndObj(), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
     
@@ -231,7 +231,7 @@ TEST(PrettyWriter, InvalidEventSequence) {
     {
         StringBuffer buffer;
         PrettyWriter<StringBuffer> writer(buffer);
-        writer.StartObject();
+        writer.StartObj();
         EXPECT_THROW(writer.Int(1), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
@@ -240,9 +240,9 @@ TEST(PrettyWriter, InvalidEventSequence) {
     {
         StringBuffer buffer;
         PrettyWriter<StringBuffer> writer(buffer);
-        writer.StartObject();
+        writer.StartObj();
         writer.Key("a");
-        EXPECT_THROW(writer.EndObject(), AssertException);
+        EXPECT_THROW(writer.EndObj(), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
     
@@ -250,11 +250,11 @@ TEST(PrettyWriter, InvalidEventSequence) {
     {
         StringBuffer buffer;
         PrettyWriter<StringBuffer> writer(buffer);
-        writer.StartObject();
+        writer.StartObj();
         writer.Key("a");
         writer.String("b");
         writer.Key("c");
-        EXPECT_THROW(writer.EndObject(), AssertException);
+        EXPECT_THROW(writer.EndObj(), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
 }
@@ -320,7 +320,7 @@ TEST(PrettyWriter, Issue_889) {
 
 static PrettyWriter<StringBuffer> WriterGen(StringBuffer &target) {
     PrettyWriter<StringBuffer> writer(target);
-    writer.StartObject();
+    writer.StartObj();
     writer.Key("a");
     writer.Int(1);
     return writer;
@@ -329,7 +329,7 @@ static PrettyWriter<StringBuffer> WriterGen(StringBuffer &target) {
 TEST(PrettyWriter, MoveCtor) {
     StringBuffer buffer;
     PrettyWriter<StringBuffer> writer(WriterGen(buffer));
-    writer.EndObject();
+    writer.EndObj();
     EXPECT_TRUE(writer.IsComplete());
     EXPECT_STREQ(
         "{\n"

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -1089,8 +1089,8 @@ TEST(Reader, ParseArray_Error) {
 #undef TEST_ARRAY_ERROR
 }
 
-struct ParseObjectHandler : BaseReaderHandler<UTF8<>, ParseObjectHandler> {
-    ParseObjectHandler() : step_(0) {}
+struct ParseObjHandler : BaseReaderHandler<UTF8<>, ParseObjHandler> {
+    ParseObjHandler() : step_(0) {}
 
     bool Default() { ADD_FAILURE(); return false; }
     bool Null() { EXPECT_EQ(8u, step_); step_++; return true; }
@@ -1125,22 +1125,22 @@ struct ParseObjectHandler : BaseReaderHandler<UTF8<>, ParseObjectHandler> {
             default: ADD_FAILURE(); return false;
         }
     }
-    bool StartObject() { EXPECT_EQ(0u, step_); step_++; return true; }
-    bool EndObject(SizeType memberCount) { EXPECT_EQ(19u, step_); EXPECT_EQ(7u, memberCount); step_++; return true; }
+    bool StartObj() { EXPECT_EQ(0u, step_); step_++; return true; }
+    bool EndObj(SizeType memberCount) { EXPECT_EQ(19u, step_); EXPECT_EQ(7u, memberCount); step_++; return true; }
     bool StartArray() { EXPECT_EQ(14u, step_); step_++; return true; }
     bool EndArray(SizeType elementCount) { EXPECT_EQ(18u, step_); EXPECT_EQ(3u, elementCount); step_++; return true; }
 
     unsigned step_;
 };
 
-TEST(Reader, ParseObject) {
+TEST(Reader, ParseObj) {
     const char* json = "{ \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] } ";
 
     // Insitu
     {
         char* json2 = StrDup(json);
         InsituStringStream s(json2);
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         reader.Parse<kParseInsituFlag>(s, h);
         EXPECT_EQ(20u, h.step_);
@@ -1150,26 +1150,26 @@ TEST(Reader, ParseObject) {
     // Normal
     {
         StringStream s(json);
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         reader.Parse(s, h);
         EXPECT_EQ(20u, h.step_);
     }
 }
 
-struct ParseEmptyObjectHandler : BaseReaderHandler<UTF8<>, ParseEmptyObjectHandler> {
-    ParseEmptyObjectHandler() : step_(0) {}
+struct ParseEmptyObjHandler : BaseReaderHandler<UTF8<>, ParseEmptyObjHandler> {
+    ParseEmptyObjHandler() : step_(0) {}
 
     bool Default() { ADD_FAILURE(); return false; }
-    bool StartObject() { EXPECT_EQ(0u, step_); step_++; return true; }
-    bool EndObject(SizeType) { EXPECT_EQ(1u, step_); step_++; return true; }
+    bool StartObj() { EXPECT_EQ(0u, step_); step_++; return true; }
+    bool EndObj(SizeType) { EXPECT_EQ(1u, step_); step_++; return true; }
 
     unsigned step_;
 };
 
-TEST(Reader, Parse_EmptyObject) {
+TEST(Reader, Parse_EmptyObj) {
     StringStream s("{ } ");
-    ParseEmptyObjectHandler h;
+    ParseEmptyObjHandler h;
     Reader reader;
     reader.Parse(s, h);
     EXPECT_EQ(2u, h.step_);
@@ -1179,8 +1179,8 @@ struct ParseMultipleRootHandler : BaseReaderHandler<UTF8<>, ParseMultipleRootHan
     ParseMultipleRootHandler() : step_(0) {}
 
     bool Default() { ADD_FAILURE(); return false; }
-    bool StartObject() { EXPECT_EQ(0u, step_); step_++; return true; }
-    bool EndObject(SizeType) { EXPECT_EQ(1u, step_); step_++; return true; }
+    bool StartObj() { EXPECT_EQ(0u, step_); step_++; return true; }
+    bool EndObj(SizeType) { EXPECT_EQ(1u, step_); step_++; return true; }
     bool StartArray() { EXPECT_EQ(2u, step_); step_++; return true; }
     bool EndArray(SizeType) { EXPECT_EQ(3u, step_); step_++; return true; }
 
@@ -1267,28 +1267,28 @@ TEST(Reader, ParseValue_Error) {
     TEST_ERROR(kParseErrorValueInvalid, ".1", 0u);
 }
 
-TEST(Reader, ParseObject_Error) {
+TEST(Reader, ParseObj_Error) {
     // Missing a name for object member.
-    TEST_ERROR(kParseErrorObjectMissName, "{1}", 1u);
-    TEST_ERROR(kParseErrorObjectMissName, "{:1}", 1u);
-    TEST_ERROR(kParseErrorObjectMissName, "{null:1}", 1u);
-    TEST_ERROR(kParseErrorObjectMissName, "{true:1}", 1u);
-    TEST_ERROR(kParseErrorObjectMissName, "{false:1}", 1u);
-    TEST_ERROR(kParseErrorObjectMissName, "{1:1}", 1u);
-    TEST_ERROR(kParseErrorObjectMissName, "{[]:1}", 1u);
-    TEST_ERROR(kParseErrorObjectMissName, "{{}:1}", 1u);
-    TEST_ERROR(kParseErrorObjectMissName, "{xyz:1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{:1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{null:1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{true:1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{false:1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{1:1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{[]:1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{{}:1}", 1u);
+    TEST_ERROR(kParseErrorObjMissName, "{xyz:1}", 1u);
 
     // Missing a colon after a name of object member.
-    TEST_ERROR(kParseErrorObjectMissColon, "{\"a\" 1}", 5u);
-    TEST_ERROR(kParseErrorObjectMissColon, "{\"a\",1}", 4u);
+    TEST_ERROR(kParseErrorObjMissColon, "{\"a\" 1}", 5u);
+    TEST_ERROR(kParseErrorObjMissColon, "{\"a\",1}", 4u);
 
     // Must be a comma or '}' after an object member
-    TEST_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, "{\"a\":1]", 6u);
+    TEST_ERROR(kParseErrorObjMissCommaOrCurlyBracket, "{\"a\":1]", 6u);
 
-    // Object cannot have a trailing comma (without kParseTrailingCommasFlag);
+    // Obj cannot have a trailing comma (without kParseTrailingCommasFlag);
     // an object member name must follow a comma
-    TEST_ERROR(kParseErrorObjectMissName, "{\"a\":1,}", 7u);
+    TEST_ERROR(kParseErrorObjMissName, "{\"a\":1,}", 7u);
 
     // This tests that MemoryStream is checking the length in Peek().
     {
@@ -1296,7 +1296,7 @@ TEST(Reader, ParseObject_Error) {
         BaseReaderHandler<> h;
         Reader reader;
         EXPECT_FALSE(reader.Parse<kParseStopWhenDoneFlag>(ms, h));
-        EXPECT_EQ(kParseErrorObjectMissName, reader.GetParseErrorCode());
+        EXPECT_EQ(kParseErrorObjMissName, reader.GetParseErrorCode());
     }
 }
 
@@ -1354,7 +1354,7 @@ struct StreamTraits<CustomStringStream<Encoding> > {
 TEST(Reader, CustomStringStream) {
     const char* json = "{ \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] } ";
     CustomStringStream<UTF8<char> > s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     reader.Parse(s, h);
     EXPECT_EQ(20u, h.step_);
@@ -1425,10 +1425,10 @@ TEST(Reader, IterativeParsing_ErrorHandling) {
     TESTERRORHANDLING("", kParseErrorDocumentEmpty, 0u);
     TESTERRORHANDLING("{}{}", kParseErrorDocumentRootNotSingular, 2u);
 
-    TESTERRORHANDLING("{1}", kParseErrorObjectMissName, 1u);
-    TESTERRORHANDLING("{\"a\", 1}", kParseErrorObjectMissColon, 4u);
-    TESTERRORHANDLING("{\"a\"}", kParseErrorObjectMissColon, 4u);
-    TESTERRORHANDLING("{\"a\": 1", kParseErrorObjectMissCommaOrCurlyBracket, 7u);
+    TESTERRORHANDLING("{1}", kParseErrorObjMissName, 1u);
+    TESTERRORHANDLING("{\"a\", 1}", kParseErrorObjMissColon, 4u);
+    TESTERRORHANDLING("{\"a\"}", kParseErrorObjMissColon, 4u);
+    TESTERRORHANDLING("{\"a\": 1", kParseErrorObjMissCommaOrCurlyBracket, 7u);
     TESTERRORHANDLING("[1 2 3]", kParseErrorArrayMissCommaOrSquareBracket, 3u);
     TESTERRORHANDLING("{\"a: 1", kParseErrorStringMissQuotationMark, 6u);
     TESTERRORHANDLING("{\"a\":}", kParseErrorValueInvalid, 5u);
@@ -1439,7 +1439,7 @@ TEST(Reader, IterativeParsing_ErrorHandling) {
     TESTERRORHANDLING("[1,,]", kParseErrorValueInvalid, 3u);
 
     // Trailing commas are not allowed without kParseTrailingCommasFlag
-    TESTERRORHANDLING("{\"a\": 1,}", kParseErrorObjectMissName, 8u);
+    TESTERRORHANDLING("{\"a\": 1,}", kParseErrorObjMissName, 8u);
     TESTERRORHANDLING("[1,2,3,]", kParseErrorValueInvalid, 7u);
 
     // Any JSON value can be a valid root element in RFC7159.
@@ -1496,11 +1496,11 @@ struct IterativeParsingReaderHandler {
 
     bool String(const Ch*, SizeType, bool) { RAPIDJSON_ASSERT(LogCount < LogCapacity); Logs[LogCount++] = LOG_STRING; return true; }
 
-    bool StartObject() { RAPIDJSON_ASSERT(LogCount < LogCapacity); Logs[LogCount++] = LOG_STARTOBJECT; return true; }
+    bool StartObj() { RAPIDJSON_ASSERT(LogCount < LogCapacity); Logs[LogCount++] = LOG_STARTOBJECT; return true; }
 
     bool Key (const Ch*, SizeType, bool) { RAPIDJSON_ASSERT(LogCount < LogCapacity); Logs[LogCount++] = LOG_KEY; return true; }
 
-    bool EndObject(SizeType c) {
+    bool EndObj(SizeType c) {
         RAPIDJSON_ASSERT(LogCount < LogCapacity);
         RAPIDJSON_ASSERT((static_cast<uint32_t>(c) & 0xF0000000) == 0);
         Logs[LogCount++] = LOG_ENDOBJECT | static_cast<uint32_t>(c);
@@ -1635,16 +1635,16 @@ TEST(Reader, IterativePullParsing_General) {
 }
 
 // Test iterative parsing on kParseErrorTermination.
-struct HandlerTerminateAtStartObject : public IterativeParsingReaderHandler<> {
-    bool StartObject() { return false; }
+struct HandlerTerminateAtStartObj : public IterativeParsingReaderHandler<> {
+    bool StartObj() { return false; }
 };
 
 struct HandlerTerminateAtStartArray : public IterativeParsingReaderHandler<> {
     bool StartArray() { return false; }
 };
 
-struct HandlerTerminateAtEndObject : public IterativeParsingReaderHandler<> {
-    bool EndObject(SizeType) { return false; }
+struct HandlerTerminateAtEndObj : public IterativeParsingReaderHandler<> {
+    bool EndObj(SizeType) { return false; }
 };
 
 struct HandlerTerminateAtEndArray : public IterativeParsingReaderHandler<> {
@@ -1653,7 +1653,7 @@ struct HandlerTerminateAtEndArray : public IterativeParsingReaderHandler<> {
 
 TEST(Reader, IterativeParsing_ShortCircuit) {
     {
-        HandlerTerminateAtStartObject handler;
+        HandlerTerminateAtStartObj handler;
         Reader reader;
         StringStream is("[1, {}]");
 
@@ -1677,7 +1677,7 @@ TEST(Reader, IterativeParsing_ShortCircuit) {
     }
 
     {
-        HandlerTerminateAtEndObject handler;
+        HandlerTerminateAtEndObj handler;
         Reader reader;
         StringStream is("[1, {}]");
 
@@ -1720,9 +1720,9 @@ struct TerminateHandler {
     bool Double(double) { return e != 6; }
     bool RawNumber(const char*, SizeType, bool) { return e != 7; }
     bool String(const char*, SizeType, bool) { return e != 8; }
-    bool StartObject() { return e != 9; }
+    bool StartObj() { return e != 9; }
     bool Key(const char*, SizeType, bool)  { return e != 10; }
-    bool EndObject(SizeType) { return e != 11; }
+    bool EndObj(SizeType) { return e != 11; }
     bool StartArray() { return e != 12; }
     bool EndArray(SizeType) { return e != 13; }
 };
@@ -1768,7 +1768,7 @@ TEST(Reader, ParseComments) {
     "}/*And the last one to be sure */";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_TRUE(reader.Parse<kParseCommentsFlag>(s, h));
     EXPECT_EQ(20u, h.step_);
@@ -1778,7 +1778,7 @@ TEST(Reader, ParseEmptyInlineComment) {
     const char* json = "{/**/\"hello\" : \"world\", \"t\" : true, \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_TRUE(reader.Parse<kParseCommentsFlag>(s, h));
     EXPECT_EQ(20u, h.step_);
@@ -1788,7 +1788,7 @@ TEST(Reader, ParseEmptyOnelineComment) {
     const char* json = "{//\n\"hello\" : \"world\", \"t\" : true, \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_TRUE(reader.Parse<kParseCommentsFlag>(s, h));
     EXPECT_EQ(20u, h.step_);
@@ -1801,7 +1801,7 @@ TEST(Reader, ParseMultipleCommentsInARow) {
     "\"hello\" : \"world\", \"t\" : true, \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_TRUE(reader.Parse<kParseCommentsFlag>(s, h));
     EXPECT_EQ(20u, h.step_);
@@ -1812,7 +1812,7 @@ TEST(Reader, InlineCommentsAreDisabledByDefault) {
         const char* json = "{/* Inline comment. */\"hello\" : \"world\", \"t\" : true, \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
 
         StringStream s(json);
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         EXPECT_FALSE(reader.Parse<kParseDefaultFlags>(s, h));
     }
@@ -1824,7 +1824,7 @@ TEST(Reader, InlineCommentsAreDisabledByDefault) {
         " and ends here */\"world\", \"t\" :true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
 
         StringStream s(json);
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         EXPECT_FALSE(reader.Parse<kParseDefaultFlags>(s, h));
     }
@@ -1834,7 +1834,7 @@ TEST(Reader, OnelineCommentsAreDisabledByDefault) {
     const char* json = "{// One-line comment\n\"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3] }";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_FALSE(reader.Parse<kParseDefaultFlags>(s, h));
 }
@@ -1843,17 +1843,17 @@ TEST(Reader, EofAfterOneLineComment) {
     const char* json = "{\"hello\" : \"world\" // EOF is here -->\0 \n}";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_FALSE(reader.Parse<kParseCommentsFlag>(s, h));
-    EXPECT_EQ(kParseErrorObjectMissCommaOrCurlyBracket, reader.GetParseErrorCode());
+    EXPECT_EQ(kParseErrorObjMissCommaOrCurlyBracket, reader.GetParseErrorCode());
 }
 
 TEST(Reader, IncompleteMultilineComment) {
     const char* json = "{\"hello\" : \"world\" /* EOF is here -->\0 */}";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_FALSE(reader.Parse<kParseCommentsFlag>(s, h));
     EXPECT_EQ(kParseErrorUnspecificSyntaxError, reader.GetParseErrorCode());
@@ -1863,7 +1863,7 @@ TEST(Reader, IncompleteMultilineComment2) {
     const char* json = "{\"hello\" : \"world\" /* *\0 */}";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_FALSE(reader.Parse<kParseCommentsFlag>(s, h));
     EXPECT_EQ(kParseErrorUnspecificSyntaxError, reader.GetParseErrorCode());
@@ -1873,7 +1873,7 @@ TEST(Reader, UnrecognizedComment) {
     const char* json = "{\"hello\" : \"world\" /! }";
 
     StringStream s(json);
-    ParseObjectHandler h;
+    ParseObjHandler h;
     Reader reader;
     EXPECT_FALSE(reader.Parse<kParseCommentsFlag>(s, h));
     EXPECT_EQ(kParseErrorUnspecificSyntaxError, reader.GetParseErrorCode());
@@ -1895,9 +1895,9 @@ struct NumbersAsStringsHandler {
         return true;
     }
     bool String(const char*, SizeType, bool) { return true; }
-    bool StartObject() { return true; }
+    bool StartObj() { return true; }
     bool Key(const char*, SizeType, bool) { return true; }
-    bool EndObject(SizeType) { return true; }
+    bool EndObj(SizeType) { return true; }
     bool StartArray() { return true; }
     bool EndArray(SizeType) { return true; }
 
@@ -2004,7 +2004,7 @@ void TestTrailingCommas() {
         const char* json = "{ \"hello\" : \"world\", \"t\" : true , \"f\" : false,"
                 "\"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3],}";
         StringStream s(json);
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         EXPECT_TRUE(reader.Parse<extraFlags|kParseTrailingCommasFlag>(s, h));
         EXPECT_EQ(20u, h.step_);
@@ -2014,7 +2014,7 @@ void TestTrailingCommas() {
         const char* json = "{ \"hello\" : \"world\", \"t\" : true , \"f\" : false,"
                 "\"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3\n,\n]\n,\n} ";
         StringStream s(json);
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         EXPECT_TRUE(reader.Parse<extraFlags|kParseTrailingCommasFlag>(s, h));
         EXPECT_EQ(20u, h.step_);
@@ -2024,7 +2024,7 @@ void TestTrailingCommas() {
         const char* json = "{ \"hello\" : \"world\", \"t\" : true , \"f\" : false, \"n\": null,"
                 "\"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3/*test*/,/*test*/]/*test*/,/*test*/}";
         StringStream s(json);
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         EXPECT_TRUE(reader.Parse<extraFlags|kParseTrailingCommasFlag|kParseCommentsFlag>(s, h));
         EXPECT_EQ(20u, h.step_);
@@ -2055,11 +2055,11 @@ void TestMultipleTrailingCommaErrors() {
         const char* json = "{ \"hello\" : \"world\", \"t\" : true , \"f\" : false,"
                 "\"n\": null, \"i\":123, \"pi\": 3.1416, \"a\":[1, 2, 3,],,}";
         StringStream s(json);
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         ParseResult r = reader.Parse<extraFlags|kParseTrailingCommasFlag>(s, h);
         EXPECT_TRUE(reader.HasParseError());
-        EXPECT_EQ(kParseErrorObjectMissName, r.Code());
+        EXPECT_EQ(kParseErrorObjMissName, r.Code());
         EXPECT_EQ(95u, r.Offset());
     }
 }
@@ -2087,11 +2087,11 @@ void TestEmptyExceptForCommaErrors() {
     }
     {
         StringStream s("{,}");
-        ParseObjectHandler h;
+        ParseObjHandler h;
         Reader reader;
         ParseResult r = reader.Parse<extraFlags|kParseTrailingCommasFlag>(s, h);
         EXPECT_TRUE(reader.HasParseError());
-        EXPECT_EQ(kParseErrorObjectMissName, r.Code());
+        EXPECT_EQ(kParseErrorObjMissName, r.Code());
         EXPECT_EQ(1u, r.Offset());
     }
 }
@@ -2116,7 +2116,7 @@ void TestTrailingCommaHandlerTermination() {
         EXPECT_EQ(7u, r.Offset());
     }
     {
-        HandlerTerminateAtEndObject h;
+        HandlerTerminateAtEndObj h;
         Reader reader;
         StringStream s("{\"t\": true, \"f\": false,}");
         ParseResult r = reader.Parse<extraFlags|kParseTrailingCommasFlag>(s, h);

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -920,7 +920,7 @@ TEST(SchemaValidator, Number_MultipleOfOne) {
         "}}");
 }
 
-TEST(SchemaValidator, Object) {
+TEST(SchemaValidator, Obj) {
     Document sd;
     sd.Parse("{\"type\":\"object\"}");
     SchemaDocument s(sd);
@@ -939,7 +939,7 @@ TEST(SchemaValidator, Object) {
         "}}");
 }
 
-TEST(SchemaValidator, Object_Properties) {
+TEST(SchemaValidator, Obj_Properties) {
     Document sd;
     sd.Parse(
         "{"
@@ -970,7 +970,7 @@ TEST(SchemaValidator, Object_Properties) {
     VALIDATE(s, "{ \"number\": 1600, \"street_name\": \"Pennsylvania\", \"street_type\": \"Avenue\", \"direction\": \"NW\" }", true);
 }
 
-TEST(SchemaValidator, Object_AdditionalPropertiesBoolean) {
+TEST(SchemaValidator, Obj_AdditionalPropertiesBoolean) {
     Document sd;
     sd.Parse(
         "{"
@@ -995,7 +995,7 @@ TEST(SchemaValidator, Object_AdditionalPropertiesBoolean) {
         "}}");
 }
 
-TEST(SchemaValidator, Object_AdditionalPropertiesObject) {
+TEST(SchemaValidator, Obj_AdditionalPropertiesObj) {
     Document sd;
     sd.Parse(
         "{"
@@ -1020,7 +1020,7 @@ TEST(SchemaValidator, Object_AdditionalPropertiesObject) {
         "}}");
 }
 
-TEST(SchemaValidator, Object_Required) {
+TEST(SchemaValidator, Obj_Required) {
     Document sd;
     sd.Parse(
         "{"
@@ -1049,7 +1049,7 @@ TEST(SchemaValidator, Object_Required) {
         "}}");
 }
 
-TEST(SchemaValidator, Object_Required_PassWithDefault) {
+TEST(SchemaValidator, Obj_Required_PassWithDefault) {
     Document sd;
     sd.Parse(
         "{"
@@ -1077,7 +1077,7 @@ TEST(SchemaValidator, Object_Required_PassWithDefault) {
         "}}");
 }
 
-TEST(SchemaValidator, Object_PropertiesRange) {
+TEST(SchemaValidator, Obj_PropertiesRange) {
     Document sd;
     sd.Parse("{\"type\":\"object\", \"minProperties\":2, \"maxProperties\":3}");
     SchemaDocument s(sd);
@@ -1101,7 +1101,7 @@ TEST(SchemaValidator, Object_PropertiesRange) {
         "}}");
 }
 
-TEST(SchemaValidator, Object_PropertyDependencies) {
+TEST(SchemaValidator, Obj_PropertyDependencies) {
     Document sd;
     sd.Parse(
         "{"
@@ -1130,7 +1130,7 @@ TEST(SchemaValidator, Object_PropertyDependencies) {
     VALIDATE(s, "{ \"name\": \"John Doe\", \"cvv_code\": 777, \"billing_address\": \"555 Debtor's Lane\" }", true);
 }
 
-TEST(SchemaValidator, Object_SchemaDependencies) {
+TEST(SchemaValidator, Obj_SchemaDependencies) {
     Document sd;
     sd.Parse(
         "{"
@@ -1166,7 +1166,7 @@ TEST(SchemaValidator, Object_SchemaDependencies) {
 }
 
 #if RAPIDJSON_SCHEMA_HAS_REGEX
-TEST(SchemaValidator, Object_PatternProperties) {
+TEST(SchemaValidator, Obj_PatternProperties) {
     Document sd;
     sd.Parse(
         "{"
@@ -1193,7 +1193,7 @@ TEST(SchemaValidator, Object_PatternProperties) {
     VALIDATE(s, "{ \"keyword\": \"value\" }", true);
 }
 
-TEST(SchemaValidator, Object_PattternProperties_ErrorConflict) {
+TEST(SchemaValidator, Obj_PattternProperties_ErrorConflict) {
     Document sd;
     sd.Parse(
         "{"
@@ -1218,7 +1218,7 @@ TEST(SchemaValidator, Object_PattternProperties_ErrorConflict) {
         "]}");
 }
 
-TEST(SchemaValidator, Object_Properties_PatternProperties) {
+TEST(SchemaValidator, Obj_Properties_PatternProperties) {
     Document sd;
     sd.Parse(
         "{"
@@ -1251,7 +1251,7 @@ TEST(SchemaValidator, Object_Properties_PatternProperties) {
         "}");
 }
 
-TEST(SchemaValidator, Object_PatternProperties_AdditionalProperties) {
+TEST(SchemaValidator, Obj_PatternProperties_AdditionalProperties) {
     Document sd;
     sd.Parse(
         "{"
@@ -1473,7 +1473,7 @@ TEST(SchemaValidator, Null) {
 
 // Additional tests
 
-TEST(SchemaValidator, ObjectInArray) {
+TEST(SchemaValidator, ObjInArray) {
     Document sd;
     sd.Parse("{\"type\":\"array\", \"items\": { \"type\":\"string\" }}");
     SchemaDocument s(sd);
@@ -1491,7 +1491,7 @@ TEST(SchemaValidator, ObjectInArray) {
         "}}");
 }
 
-TEST(SchemaValidator, MultiTypeInObject) {
+TEST(SchemaValidator, MultiTypeInObj) {
     Document sd;
     sd.Parse(
         "{"
@@ -1513,7 +1513,7 @@ TEST(SchemaValidator, MultiTypeInObject) {
         "}}");
 }
 
-TEST(SchemaValidator, MultiTypeWithObject) {
+TEST(SchemaValidator, MultiTypeWithObj) {
     Document sd;
     sd.Parse(
         "{"
@@ -1983,7 +1983,7 @@ TEST(SchemaValidator, Issue608) {
         "}}");
 }
 
-// Fail to resolve $ref in allOf causes crash in SchemaValidator::StartObject()
+// Fail to resolve $ref in allOf causes crash in SchemaValidator::StartObj()
 TEST(SchemaValidator, Issue728_AllOfRef) {
     Document sd;
     sd.Parse("{\"allOf\": [{\"$ref\": \"#/abc\"}]}");
@@ -2005,14 +2005,14 @@ TEST(SchemaValidator, Issue1017_allOfHandler) {
     StringBuffer sb;
     Writer<StringBuffer> writer(sb);
     GenericSchemaValidator<SchemaDocument, Writer<StringBuffer> > validator(s, writer);
-    EXPECT_TRUE(validator.StartObject());
+    EXPECT_TRUE(validator.StartObj());
     EXPECT_TRUE(validator.Key("cyanArray2", 10, false));
     EXPECT_TRUE(validator.StartArray());    
     EXPECT_TRUE(validator.EndArray(0));    
     EXPECT_TRUE(validator.Key("blackArray", 10, false));
     EXPECT_TRUE(validator.StartArray());    
     EXPECT_TRUE(validator.EndArray(0));    
-    EXPECT_TRUE(validator.EndObject(0));
+    EXPECT_TRUE(validator.EndObj(0));
     EXPECT_TRUE(validator.IsValid());
     EXPECT_STREQ("{\"cyanArray2\":[],\"blackArray\":[]}", sb.GetString());
 }

--- a/test/unittest/unittest.cpp
+++ b/test/unittest/unittest.cpp
@@ -45,7 +45,7 @@ int main(int argc, char **argv) {
 
 #ifdef _MSC_VER
     // Current gtest constantly leak 2 blocks at exit
-    _CrtMemDumpAllObjectsSince(&memoryState);
+    _CrtMemDumpAllObjsSince(&memoryState);
 #endif
     return ret;
 }

--- a/test/unittest/valuetest.cpp
+++ b/test/unittest/valuetest.cpp
@@ -179,7 +179,7 @@ void TestUnequal(const A& a, const B& b) {
 
 TEST(Value, EqualtoOperator) {
     Value::AllocatorType allocator;
-    Value x(kObjectType);
+    Value x(kObjType);
     x.AddMember("hello", "world", allocator)
         .AddMember("t", Value(true).Move(), allocator)
         .AddMember("f", Value(false).Move(), allocator)
@@ -287,10 +287,10 @@ TEST(Value, CopyFrom) {
 
 TEST(Value, Swap) {
     Value v1(1234);
-    Value v2(kObjectType);
+    Value v2(kObjType);
 
     EXPECT_EQ(&v1, &v1.Swap(v2));
-    EXPECT_TRUE(v1.IsObject());
+    EXPECT_TRUE(v1.IsObj());
     EXPECT_TRUE(v2.IsInt());
     EXPECT_EQ(1234, v2.GetInt());
 
@@ -298,7 +298,7 @@ TEST(Value, Swap) {
     using std::swap;
     swap(v1, v2);
     EXPECT_TRUE(v1.IsInt());
-    EXPECT_TRUE(v2.IsObject());
+    EXPECT_TRUE(v2.IsObj());
 }
 
 TEST(Value, Null) {
@@ -311,7 +311,7 @@ TEST(Value, Null) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsNumber());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     // Constructor with type
@@ -336,7 +336,7 @@ TEST(Value, True) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsNumber());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     // Constructor with type
@@ -368,7 +368,7 @@ TEST(Value, False) {
     //EXPECT_FALSE((bool)x);
     EXPECT_FALSE(x.IsNumber());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     // Constructor with type
@@ -408,7 +408,7 @@ TEST(Value, Int) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsTrue());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     Value nx(-1234);
@@ -474,7 +474,7 @@ TEST(Value, Uint) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsTrue());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     // SetUint()
@@ -530,7 +530,7 @@ TEST(Value, Int64) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsTrue());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     Value nx(int64_t(-1234));
@@ -594,7 +594,7 @@ TEST(Value, Uint64) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsTrue());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     // SetUint64()
@@ -639,7 +639,7 @@ TEST(Value, Double) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsTrue());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     // SetDouble()
@@ -672,7 +672,7 @@ TEST(Value, Float) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsTrue());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     // SetFloat()
@@ -742,7 +742,7 @@ TEST(Value, String) {
     EXPECT_FALSE(x.IsBool());
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsTrue());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
     EXPECT_FALSE(x.IsArray());
 
     static const char cstr[] = "World"; // const array
@@ -1095,7 +1095,7 @@ TEST(Value, Array) {
     EXPECT_FALSE(x.IsFalse());
     EXPECT_FALSE(x.IsTrue());
     EXPECT_FALSE(x.IsString());
-    EXPECT_FALSE(x.IsObject());
+    EXPECT_FALSE(x.IsObj());
 
     TestArray(x, allocator);
 
@@ -1213,12 +1213,12 @@ TEST(Value, ArrayHelperRangeFor) {
 #endif
 
 template <typename T, typename Allocator>
-static void TestObject(T& x, Allocator& allocator) {
+static void TestObj(T& x, Allocator& allocator) {
     const T& y = x; // const version
 
     // AddMember()
     x.AddMember("A", "Apple", allocator);
-    EXPECT_FALSE(x.ObjectEmpty());
+    EXPECT_FALSE(x.ObjEmpty());
     EXPECT_EQ(1u, x.MemberCount());
 
     Value value("Banana", 6);
@@ -1227,7 +1227,7 @@ static void TestObject(T& x, Allocator& allocator) {
 
     // AddMember<T>(StringRefType, T, Allocator)
     {
-        Value o(kObjectType);
+        Value o(kObjType);
         o.AddMember("true", true, allocator);
         o.AddMember("false", false, allocator);
         o.AddMember("int", -1, allocator);
@@ -1249,7 +1249,7 @@ static void TestObject(T& x, Allocator& allocator) {
 
     // AddMember<T>(Value&, T, Allocator)
     {
-        Value o(kObjectType);
+        Value o(kObjType);
 
         Value n("s");
         o.AddMember(n, "string", allocator);
@@ -1263,20 +1263,20 @@ static void TestObject(T& x, Allocator& allocator) {
 #if RAPIDJSON_HAS_STDSTRING
     {
         // AddMember(StringRefType, const std::string&, Allocator)
-        Value o(kObjectType);
+        Value o(kObjType);
         o.AddMember("b", std::string("Banana"), allocator);
         EXPECT_STREQ("Banana", o["b"].GetString());
 
         // RemoveMember(const std::string&)
         o.RemoveMember(std::string("b"));
-        EXPECT_TRUE(o.ObjectEmpty());
+        EXPECT_TRUE(o.ObjEmpty());
     }
 #endif
 
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
     // AddMember(GenericValue&&, ...) variants
     {
-        Value o(kObjectType);
+        Value o(kObjType);
         o.AddMember(Value("true"), Value(true), allocator);
         o.AddMember(Value("false"), Value(false).Move(), allocator);    // value is lvalue ref
         o.AddMember(Value("int").Move(), Value(-1), allocator);         // name is lvalue ref
@@ -1476,91 +1476,91 @@ static void TestObject(T& x, Allocator& allocator) {
 
     // RemoveAllMembers()
     x.RemoveAllMembers();
-    EXPECT_TRUE(x.ObjectEmpty());
+    EXPECT_TRUE(x.ObjEmpty());
     EXPECT_EQ(0u, x.MemberCount());
 }
 
-TEST(Value, Object) {
-    Value x(kObjectType);
+TEST(Value, Obj) {
+    Value x(kObjType);
     const Value& y = x; // const version
     Value::AllocatorType allocator;
 
-    EXPECT_EQ(kObjectType, x.GetType());
-    EXPECT_TRUE(x.IsObject());
-    EXPECT_TRUE(x.ObjectEmpty());
+    EXPECT_EQ(kObjType, x.GetType());
+    EXPECT_TRUE(x.IsObj());
+    EXPECT_TRUE(x.ObjEmpty());
     EXPECT_EQ(0u, x.MemberCount());
-    EXPECT_EQ(kObjectType, y.GetType());
-    EXPECT_TRUE(y.IsObject());
-    EXPECT_TRUE(y.ObjectEmpty());
+    EXPECT_EQ(kObjType, y.GetType());
+    EXPECT_TRUE(y.IsObj());
+    EXPECT_TRUE(y.ObjEmpty());
     EXPECT_EQ(0u, y.MemberCount());
 
-    TestObject(x, allocator);
+    TestObj(x, allocator);
 
-    // SetObject()
+    // SetObj()
     Value z;
-    z.SetObject();
-    EXPECT_TRUE(z.IsObject());
+    z.SetObj();
+    EXPECT_TRUE(z.IsObj());
 }
 
-TEST(Value, ObjectHelper) {
+TEST(Value, ObjHelper) {
     Value::AllocatorType allocator;
     {
-        Value x(kObjectType);
-        Value::Object o = x.GetObject();
-        TestObject(o, allocator);
+        Value x(kObjType);
+        Value::Obj o = x.GetObj();
+        TestObj(o, allocator);
     }
 
     {
-        Value x(kObjectType);
-        Value::Object o = x.GetObject();
+        Value x(kObjType);
+        Value::Obj o = x.GetObj();
         o.AddMember("1", 1, allocator);
 
-        Value::Object o2(o); // copy constructor
+        Value::Obj o2(o); // copy constructor
         EXPECT_EQ(1u, o2.MemberCount());
 
-        Value::Object o3 = o;
+        Value::Obj o3 = o;
         EXPECT_EQ(1u, o3.MemberCount());
 
-        Value::ConstObject y = static_cast<const Value&>(x).GetObject();
+        Value::ConstObj y = static_cast<const Value&>(x).GetObj();
         (void)y;
         // y.AddMember("1", 1, allocator); // should not compile
 
         // Templated functions
         x.RemoveAllMembers();
-        EXPECT_TRUE(x.Is<Value::Object>());
-        EXPECT_TRUE(x.Is<Value::ConstObject>());
+        EXPECT_TRUE(x.Is<Value::Obj>());
+        EXPECT_TRUE(x.Is<Value::ConstObj>());
         o.AddMember("1", 1, allocator);
-        EXPECT_EQ(1, x.Get<Value::Object>()["1"].GetInt());
-        EXPECT_EQ(1, x.Get<Value::ConstObject>()["1"].GetInt());
+        EXPECT_EQ(1, x.Get<Value::Obj>()["1"].GetInt());
+        EXPECT_EQ(1, x.Get<Value::ConstObj>()["1"].GetInt());
 
         Value x2;
-        x2.Set<Value::Object>(o);
-        EXPECT_TRUE(x.IsObject());   // IsObject() is invariant after moving
-        EXPECT_EQ(1, x2.Get<Value::Object>()["1"].GetInt());
+        x2.Set<Value::Obj>(o);
+        EXPECT_TRUE(x.IsObj());   // IsObj() is invariant after moving
+        EXPECT_EQ(1, x2.Get<Value::Obj>()["1"].GetInt());
     }
 
     {
-        Value x(kObjectType);
+        Value x(kObjType);
         x.AddMember("a", "apple", allocator);
-        Value y(x.GetObject());
+        Value y(x.GetObj());
         EXPECT_STREQ("apple", y["a"].GetString());
-        EXPECT_TRUE(x.IsObject());  // Invariant
+        EXPECT_TRUE(x.IsObj());  // Invariant
     }
     
     {
-        Value x(kObjectType);
+        Value x(kObjType);
         x.AddMember("a", "apple", allocator);
-        Value y(kObjectType);
-        y.AddMember("fruits", x.GetObject(), allocator);
+        Value y(kObjType);
+        y.AddMember("fruits", x.GetObj(), allocator);
         EXPECT_STREQ("apple", y["fruits"]["a"].GetString());
-        EXPECT_TRUE(x.IsObject());  // Invariant
+        EXPECT_TRUE(x.IsObj());  // Invariant
     }
 }
 
 #if RAPIDJSON_HAS_CXX11_RANGE_FOR
-TEST(Value, ObjectHelperRangeFor) {
+TEST(Value, ObjHelperRangeFor) {
     Value::AllocatorType allocator;
-    Value x(kObjectType);
+    Value x(kObjType);
 
     for (int i = 0; i < 10; i++) {
         char name[10];
@@ -1570,7 +1570,7 @@ TEST(Value, ObjectHelperRangeFor) {
 
     {
         int i = 0;
-        for (auto& m : x.GetObject()) {
+        for (auto& m : x.GetObj()) {
             char name[10];
             sprintf(name, "%d", i);
             EXPECT_STREQ(name, m.name.GetString());
@@ -1581,7 +1581,7 @@ TEST(Value, ObjectHelperRangeFor) {
     }
     {
         int i = 0;
-        for (const auto& m : const_cast<const Value&>(x).GetObject()) {
+        for (const auto& m : const_cast<const Value&>(x).GetObj()) {
             char name[10];
             sprintf(name, "%d", i);
             EXPECT_STREQ(name, m.name.GetString());
@@ -1591,14 +1591,14 @@ TEST(Value, ObjectHelperRangeFor) {
         EXPECT_EQ(i, 10);
     }
 
-    // Object a = x.GetObject();
-    // Object ca = const_cast<const Value&>(x).GetObject();
+    // Obj a = x.GetObj();
+    // Obj ca = const_cast<const Value&>(x).GetObj();
 }
 #endif
 
 TEST(Value, EraseMember_String) {
     Value::AllocatorType allocator;
-    Value x(kObjectType);
+    Value x(kObjType);
     x.AddMember("A", "Apple", allocator);
     x.AddMember("B", "Banana", allocator);
 
@@ -1635,9 +1635,9 @@ TEST(Value, BigNestedArray) {
         }
 }
 
-TEST(Value, BigNestedObject) {
+TEST(Value, BigNestedObj) {
     MemoryPoolAllocator<> allocator;
-    Value x(kObjectType);
+    Value x(kObjType);
     static const SizeType n = 200;
 
     for (SizeType i = 0; i < n; i++) {
@@ -1646,7 +1646,7 @@ TEST(Value, BigNestedObject) {
 
         // Value name(name1); // should not compile
         Value name(name1, static_cast<SizeType>(strlen(name1)), allocator);
-        Value object(kObjectType);
+        Value object(kObjType);
 
         for (SizeType j = 0; j < n; j++) {
             char name2[10];
@@ -1679,7 +1679,7 @@ TEST(Value, BigNestedObject) {
 TEST(Value, RemoveLastElement) {
     rapidjson::Document doc;
     rapidjson::Document::AllocatorType& allocator = doc.GetAllocator();
-    rapidjson::Value objVal(rapidjson::kObjectType);        
+    rapidjson::Value objVal(rapidjson::kObjType);        
     objVal.AddMember("var1", 123, allocator);       
     objVal.AddMember("var2", "444", allocator);
     objVal.AddMember("var3", 555, allocator);
@@ -1693,7 +1693,7 @@ TEST(Document, CrtAllocator) {
     typedef GenericValue<UTF8<>, CrtAllocator> V;
 
     V::AllocatorType allocator;
-    V o(kObjectType);
+    V o(kObjType);
     o.AddMember("x", 1, allocator); // Should not call destructor on uninitialized name/value of newly allocated members.
 
     V a(kArrayType);
@@ -1731,9 +1731,9 @@ struct TerminateHandler {
     bool Double(double) { return e != 6; }
     bool RawNumber(const char*, SizeType, bool) { return e != 7; }
     bool String(const char*, SizeType, bool) { return e != 8; }
-    bool StartObject() { return e != 9; }
+    bool StartObj() { return e != 9; }
     bool Key(const char*, SizeType, bool)  { return e != 10; }
-    bool EndObject(SizeType) { return e != 11; }
+    bool EndObj(SizeType) { return e != 11; }
     bool StartArray() { return e != 12; }
     bool EndArray(SizeType) { return e != 13; }
 };
@@ -1788,7 +1788,7 @@ TEST(Value, Sorting) {
 // http://stackoverflow.com/questions/35222230/
 
 static void MergeDuplicateKey(Value& v, Value::AllocatorType& a) {
-    if (v.IsObject()) {
+    if (v.IsObj()) {
         // Convert all key:value into key:[value]
         for (Value::MemberIterator itr = v.MemberBegin(); itr != v.MemberEnd(); ++itr)
             itr->value = Value(kArrayType).Move().PushBack(itr->value, a);

--- a/test/unittest/writertest.cpp
+++ b/test/unittest/writertest.cpp
@@ -252,12 +252,12 @@ TEST(Writer, AssertRootMayBeAnyValue) {
 #undef T
 }
 
-TEST(Writer, AssertIncorrectObjectLevel) {
+TEST(Writer, AssertIncorrectObjLevel) {
     StringBuffer buffer;
     Writer<StringBuffer> writer(buffer);
-    writer.StartObject();
-    writer.EndObject();
-    ASSERT_THROW(writer.EndObject(), AssertException);
+    writer.StartObj();
+    writer.EndObj();
+    ASSERT_THROW(writer.EndObj(), AssertException);
 }
 
 TEST(Writer, AssertIncorrectArrayLevel) {
@@ -268,26 +268,26 @@ TEST(Writer, AssertIncorrectArrayLevel) {
     ASSERT_THROW(writer.EndArray(), AssertException);
 }
 
-TEST(Writer, AssertIncorrectEndObject) {
+TEST(Writer, AssertIncorrectEndObj) {
     StringBuffer buffer;
     Writer<StringBuffer> writer(buffer);
-    writer.StartObject();
+    writer.StartObj();
     ASSERT_THROW(writer.EndArray(), AssertException);
 }
 
 TEST(Writer, AssertIncorrectEndArray) {
     StringBuffer buffer;
     Writer<StringBuffer> writer(buffer);
-    writer.StartObject();
+    writer.StartObj();
     ASSERT_THROW(writer.EndArray(), AssertException);
 }
 
-TEST(Writer, AssertObjectKeyNotString) {
+TEST(Writer, AssertObjKeyNotString) {
 #define T(x)\
     {\
         StringBuffer buffer;\
         Writer<StringBuffer> writer(buffer);\
-        writer.StartObject();\
+        writer.StartObj();\
         ASSERT_THROW(x, AssertException); \
     }
     T(writer.Bool(false));
@@ -298,7 +298,7 @@ TEST(Writer, AssertObjectKeyNotString) {
     T(writer.Int64(0));
     T(writer.Uint64(0));
     T(writer.Double(0));
-    T(writer.StartObject());
+    T(writer.StartObj());
     T(writer.StartArray());
 #undef T
 }
@@ -307,9 +307,9 @@ TEST(Writer, AssertMultipleRoot) {
     StringBuffer buffer;
     Writer<StringBuffer> writer(buffer);
 
-    writer.StartObject();
-    writer.EndObject();
-    ASSERT_THROW(writer.StartObject(), AssertException);
+    writer.StartObj();
+    writer.EndObj();
+    ASSERT_THROW(writer.StartObj(), AssertException);
 
     writer.Reset(buffer);
     writer.Null();
@@ -325,17 +325,17 @@ TEST(Writer, AssertMultipleRoot) {
     //ASSERT_THROW(writer.Double(3.14), AssertException);
 }
 
-TEST(Writer, RootObjectIsComplete) {
+TEST(Writer, RootObjIsComplete) {
     StringBuffer buffer;
     Writer<StringBuffer> writer(buffer);
     EXPECT_FALSE(writer.IsComplete());
-    writer.StartObject();
+    writer.StartObj();
     EXPECT_FALSE(writer.IsComplete());
     writer.String("foo");
     EXPECT_FALSE(writer.IsComplete());
     writer.Int(1);
     EXPECT_FALSE(writer.IsComplete());
-    writer.EndObject();
+    writer.EndObj();
     EXPECT_TRUE(writer.IsComplete());
 }
 
@@ -435,7 +435,7 @@ TEST(Writer, InvalidEventSequence) {
     {
         StringBuffer buffer;
         Writer<StringBuffer> writer(buffer);
-        writer.StartObject();
+        writer.StartObj();
         EXPECT_THROW(writer.EndArray(), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
@@ -445,7 +445,7 @@ TEST(Writer, InvalidEventSequence) {
         StringBuffer buffer;
         Writer<StringBuffer> writer(buffer);
         writer.StartArray();
-        EXPECT_THROW(writer.EndObject(), AssertException);
+        EXPECT_THROW(writer.EndObj(), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
 
@@ -453,7 +453,7 @@ TEST(Writer, InvalidEventSequence) {
     {
         StringBuffer buffer;
         Writer<StringBuffer> writer(buffer);
-        writer.StartObject();
+        writer.StartObj();
         EXPECT_THROW(writer.Int(1), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
@@ -462,9 +462,9 @@ TEST(Writer, InvalidEventSequence) {
     {
         StringBuffer buffer;
         Writer<StringBuffer> writer(buffer);
-        writer.StartObject();
+        writer.StartObj();
         writer.Key("a");
-        EXPECT_THROW(writer.EndObject(), AssertException);
+        EXPECT_THROW(writer.EndObj(), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
 
@@ -472,11 +472,11 @@ TEST(Writer, InvalidEventSequence) {
     {
         StringBuffer buffer;
         Writer<StringBuffer> writer(buffer);
-        writer.StartObject();
+        writer.StartObj();
         writer.Key("a");
         writer.String("b");
         writer.Key("c");
-        EXPECT_THROW(writer.EndObject(), AssertException);
+        EXPECT_THROW(writer.EndObj(), AssertException);
         EXPECT_FALSE(writer.IsComplete());
     }
 }
@@ -527,13 +527,13 @@ TEST(Writer, Inf) {
 TEST(Writer, RawValue) {
     StringBuffer buffer;
     Writer<StringBuffer> writer(buffer);
-    writer.StartObject();
+    writer.StartObj();
     writer.Key("a");
     writer.Int(1);
     writer.Key("raw");
     const char json[] = "[\"Hello\\nWorld\", 123.456]";
     writer.RawValue(json, strlen(json), kArrayType);
-    writer.EndObject();
+    writer.EndObj();
     EXPECT_TRUE(writer.IsComplete());
     EXPECT_STREQ("{\"a\":1,\"raw\":[\"Hello\\nWorld\", 123.456]}", buffer.GetString());
 }
@@ -578,7 +578,7 @@ TEST(Write, RawValue_Issue1152) {
 #if RAPIDJSON_HAS_CXX11_RVALUE_REFS
 static Writer<StringBuffer> WriterGen(StringBuffer &target) {
     Writer<StringBuffer> writer(target);
-    writer.StartObject();
+    writer.StartObj();
     writer.Key("a");
     writer.Int(1);
     return writer;
@@ -587,7 +587,7 @@ static Writer<StringBuffer> WriterGen(StringBuffer &target) {
 TEST(Writer, MoveCtor) {
     StringBuffer buffer;
     Writer<StringBuffer> writer(WriterGen(buffer));
-    writer.EndObject();
+    writer.EndObj();
     EXPECT_TRUE(writer.IsComplete());
     EXPECT_STREQ("{\"a\":1}", buffer.GetString());
 }


### PR DESCRIPTION
Fix Function Name Conflict between rapidjson::GenericValue<···>::GetObject() and GetObject macro defined in the windows headers (wingdi.h)