### PR TITLE
Fix StdAllocator deprecation errors in C++17 mode

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -449,11 +449,17 @@ public:
     ~StdAllocator() RAPIDJSON_NOEXCEPT
     { }
 
-    typedef typename allocator_type::value_type       value_type;
+#if RAPIDJSON_HAS_CXX17
+    typedef typename std::allocator_traits<allocator_type>::pointer        pointer;
+    typedef typename std::allocator_traits<allocator_type>::const_pointer  const_pointer;
+#else
     typedef typename allocator_type::pointer          pointer;
     typedef typename allocator_type::const_pointer    const_pointer;
     typedef typename allocator_type::reference        reference;
     typedef typename allocator_type::const_reference  const_reference;
+#endif
+
+    typedef typename allocator_type::value_type       value_type;
     typedef typename allocator_type::size_type        size_type;
     typedef typename allocator_type::difference_type  difference_type;
 
@@ -462,7 +468,22 @@ public:
         typedef StdAllocator<U, BaseAllocator> other;
     };
 
-#if RAPIDJSON_HAS_CXX11
+#if RAPIDJSON_HAS_CXX17
+    size_t max_size() const RAPIDJSON_NOEXCEPT
+    {
+        return std::allocator_traits<allocator_type>::max_size(*this);
+    }
+
+    template<typename... Args>
+    void construct(pointer p, Args&&... args)
+    {
+        std::allocator_traits<allocator_type>::construct(*this, p, std::forward<Args>(args)...);
+    }
+    void destroy(pointer p)
+    {
+        std::allocator_traits<allocator_type>::destroy(*this, p);
+    }
+#elif RAPIDJSON_HAS_CXX11
     using allocator_type::max_size;
     using allocator_type::address;
     using allocator_type::construct;

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -391,6 +391,19 @@ using std::size_t;
 RAPIDJSON_NAMESPACE_END
 
 ///////////////////////////////////////////////////////////////////////////////
+// __cplusplus macro
+
+//!@cond RAPIDJSON_HIDDEN_FROM_DOXYGEN
+
+#if defined(_MSC_VER)
+#define RAPIDJSON_CPLUSPLUS _MSVC_LANG
+#else
+#define RAPIDJSON_CPLUSPLUS __cplusplus
+#endif
+
+//!@endcond
+
+///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_ASSERT
 
 //! Assertion.
@@ -411,7 +424,7 @@ RAPIDJSON_NAMESPACE_END
 
 // Prefer C++11 static_assert, if available
 #ifndef RAPIDJSON_STATIC_ASSERT
-#if __cplusplus >= 201103L || ( defined(_MSC_VER) && _MSC_VER >= 1800 )
+#if RAPIDJSON_CPLUSPLUS >= 201103L
 #define RAPIDJSON_STATIC_ASSERT(x) \
    static_assert(x, RAPIDJSON_STRINGIFY(x))
 #endif // C++11
@@ -542,7 +555,7 @@ RAPIDJSON_NAMESPACE_END
 // C++11 features
 
 #ifndef RAPIDJSON_HAS_CXX11
-#define RAPIDJSON_HAS_CXX11 (__cplusplus >= 201103L)
+#define RAPIDJSON_HAS_CXX11 (RAPIDJSON_CPLUSPLUS >= 201103L)
 #endif
 
 #ifndef RAPIDJSON_HAS_CXX11_RVALUE_REFS
@@ -609,6 +622,10 @@ RAPIDJSON_NAMESPACE_END
 
 ///////////////////////////////////////////////////////////////////////////////
 // C++17 features
+
+#ifndef RAPIDJSON_HAS_CXX17
+#define RAPIDJSON_HAS_CXX17 (RAPIDJSON_CPLUSPLUS >= 201703L)
+#endif
 
 #if defined(__has_cpp_attribute)
 # if __has_cpp_attribute(fallthrough)

--- a/test/unittest/allocatorstest.cpp
+++ b/test/unittest/allocatorstest.cpp
@@ -92,11 +92,13 @@ void TestStdAllocator(const Allocator& a) {
     EXPECT_TRUE(ba == ba2);
     EXPECT_FALSE(ba != ba2);
 
+    StdAllocator<unsigned long long, Allocator> lla(a);
+#if !RAPIDJSON_HAS_CXX17
     unsigned long long ll = 0, *llp = &ll;
     const unsigned long long cll = 0, *cllp = &cll;
-    StdAllocator<unsigned long long, Allocator> lla(a);
     EXPECT_EQ(lla.address(ll), llp);
     EXPECT_EQ(lla.address(cll), cllp);
+#endif
     EXPECT_TRUE(lla.max_size() > 0 && lla.max_size() <= SIZE_MAX / sizeof(unsigned long long));
 
     int *arr;


### PR DESCRIPTION
This fixes a bug introduced in #1858 which prevented from using RapidJSON under MSVC when `/std:c++17` or `/std:c++latest` was used, because the added code used members which where deprecated in C++17 and removed in C++20. This triggered an error.