### PR TITLE
Make StdAllocator C++17-20 compatible.

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -20,7 +20,6 @@
 #include <memory>
 
 #if RAPIDJSON_HAS_CXX11
-#include <limits>
 #include <type_traits>
 #endif
 
@@ -466,6 +465,7 @@ public:
 
     typedef typename traits_type::size_type         size_type;
     typedef typename traits_type::difference_type   difference_type;
+
     typedef typename traits_type::value_type        value_type;
     typedef typename traits_type::pointer           pointer;
     typedef typename traits_type::const_pointer     const_pointer;
@@ -484,19 +484,19 @@ public:
         return std::addressof(r);
     }
 
-    size_t max_size() const RAPIDJSON_NOEXCEPT
+    size_type max_size() const RAPIDJSON_NOEXCEPT
     {
-        return std::numeric_limits<size_type>::max() / sizeof(value_type);
+        return traits_type::max_size(*this);
     }
 
     template <typename ...Args>
-    void construct(pointer p, Args &&...args)
+    void construct(pointer p, Args&&... args)
     {
-        ::new (static_cast<void*>(p)) value_type(std::forward<Args>(args)...);
+        traits_type::construct(*this, p, std::forward<Args>(args)...);
     }
     void destroy(pointer p)
     {
-        p->~T();
+        traits_type::destroy(*this, p);
     }
 
 #else // !RAPIDJSON_HAS_CXX11
@@ -513,7 +513,7 @@ public:
         return allocator_type::address(r);
     }
 
-    size_t max_size() const RAPIDJSON_NOEXCEPT
+    size_type max_size() const RAPIDJSON_NOEXCEPT
     {
         return allocator_type::max_size();
     }
@@ -615,12 +615,12 @@ public:
     ~StdAllocator() RAPIDJSON_NOEXCEPT
     { }
 
-    typedef typename allocator_type::value_type value_type;
-
     template<typename U>
     struct rebind {
         typedef StdAllocator<U, BaseAllocator> other;
     };
+
+    typedef typename allocator_type::value_type value_type;
 
 private:
     template <typename, typename>

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -135,6 +135,8 @@
 #define RAPIDJSON_CPLUSPLUS __cplusplus
 #endif
 
+//!@endcond
+
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_HAS_STDSTRING
 
@@ -627,10 +629,14 @@ RAPIDJSON_NAMESPACE_END
 
 #if RAPIDJSON_HAS_CXX17
 # define RAPIDJSON_DELIBERATE_FALLTHROUGH [[fallthrough]]
-#elif defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough)
-# define RAPIDJSON_DELIBERATE_FALLTHROUGH __attribute__((fallthrough))
-#elif defined(__has_cpp_attribute) && __has_cpp_attribute(clang::fallthrough)
-# define RAPIDJSON_DELIBERATE_FALLTHROUGH [[clang::fallthrough]]
+#elif defined(__has_cpp_attribute)
+# if __has_cpp_attribute(clang::fallthrough)
+#  define RAPIDJSON_DELIBERATE_FALLTHROUGH [[clang::fallthrough]]
+# elif __has_cpp_attribute(fallthrough)
+#  define RAPIDJSON_DELIBERATE_FALLTHROUGH __attribute__((fallthrough))
+# else
+#  define RAPIDJSON_DELIBERATE_FALLTHROUGH
+# endif
 #else
 # define RAPIDJSON_DELIBERATE_FALLTHROUGH
 #endif

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -125,6 +125,17 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
+// __cplusplus macro
+
+//!@cond RAPIDJSON_HIDDEN_FROM_DOXYGEN
+
+#if defined(_MSC_VER)
+#define RAPIDJSON_CPLUSPLUS _MSVC_LANG
+#else
+#define RAPIDJSON_CPLUSPLUS __cplusplus
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_HAS_STDSTRING
 
 #ifndef RAPIDJSON_HAS_STDSTRING
@@ -411,7 +422,7 @@ RAPIDJSON_NAMESPACE_END
 
 // Prefer C++11 static_assert, if available
 #ifndef RAPIDJSON_STATIC_ASSERT
-#if __cplusplus >= 201103L || ( defined(_MSC_VER) && _MSC_VER >= 1800 )
+#if RAPIDJSON_CPLUSPLUS >= 201103L || ( defined(_MSC_VER) && _MSC_VER >= 1800 )
 #define RAPIDJSON_STATIC_ASSERT(x) \
    static_assert(x, RAPIDJSON_STRINGIFY(x))
 #endif // C++11
@@ -542,7 +553,7 @@ RAPIDJSON_NAMESPACE_END
 // C++11 features
 
 #ifndef RAPIDJSON_HAS_CXX11
-#define RAPIDJSON_HAS_CXX11 (__cplusplus >= 201103L)
+#define RAPIDJSON_HAS_CXX11 (RAPIDJSON_CPLUSPLUS >= 201103L)
 #endif
 
 #ifndef RAPIDJSON_HAS_CXX11_RVALUE_REFS
@@ -610,12 +621,16 @@ RAPIDJSON_NAMESPACE_END
 ///////////////////////////////////////////////////////////////////////////////
 // C++17 features
 
-#if defined(__has_cpp_attribute)
-# if __has_cpp_attribute(fallthrough)
-#  define RAPIDJSON_DELIBERATE_FALLTHROUGH [[fallthrough]]
-# else
-#  define RAPIDJSON_DELIBERATE_FALLTHROUGH
-# endif
+#ifndef RAPIDJSON_HAS_CXX17
+#define RAPIDJSON_HAS_CXX17 (RAPIDJSON_CPLUSPLUS >= 201703L)
+#endif
+
+#if RAPIDJSON_HAS_CXX17
+# define RAPIDJSON_DELIBERATE_FALLTHROUGH [[fallthrough]]
+#elif defined(__has_cpp_attribute) && __has_cpp_attribute(fallthrough)
+# define RAPIDJSON_DELIBERATE_FALLTHROUGH __attribute__((fallthrough))
+#elif defined(__has_cpp_attribute) && __has_cpp_attribute(clang::fallthrough)
+# define RAPIDJSON_DELIBERATE_FALLTHROUGH [[clang::fallthrough]]
 #else
 # define RAPIDJSON_DELIBERATE_FALLTHROUGH
 #endif

--- a/test/unittest/allocatorstest.cpp
+++ b/test/unittest/allocatorstest.cpp
@@ -107,12 +107,12 @@ void TestStdAllocator(const Allocator& a) {
         arr[i] = 0x0f0f0f0f;
     }
     ia.deallocate(arr, 10);
-    arr = (int *)ia.Malloc(10 * sizeof(int));
+    arr = Malloc<int>(ia, 10);
     EXPECT_TRUE(arr != 0);
     for (int i = 0; i < 10; ++i) {
         arr[i] = 0x0f0f0f0f;
     }
-    arr = (int *)ia.Realloc(arr, 10 * sizeof(int), 20 * sizeof(int));
+    arr = Realloc<int>(ia, arr, 10, 20);
     EXPECT_TRUE(arr != 0);
     for (int i = 0; i < 10; ++i) {
         EXPECT_EQ(arr[i], 0x0f0f0f0f);
@@ -120,7 +120,7 @@ void TestStdAllocator(const Allocator& a) {
     for (int i = 10; i < 20; i++) {
         arr[i] = 0x0f0f0f0f;
     }
-    ia.Free(arr);
+    Free<int>(ia, arr, 20);
 
     int cons = 0, dest = 0;
     StdAllocator<TestStdAllocatorData, Allocator> da(a);


### PR DESCRIPTION
Alternatively to #1865, this proposal (also) fixes StdAllocator with regard to C++17 and later, though the choice here is to keep the same interface for StdAllocator (the C++11 and earlier one) even if compiled with newer C++ versions. Since std::allocator_traits is already available in C++11, there is no need for C++17 or C++20 specifics to allow for that.

While at it, this PR also fixes RAPIDJSON_DELIBERATE_FALLTHROUGH which is not valid with a compiler which __has_cpp_attribute(fallthrough) but still [[fallthrough]] is not usable because -std=C++98 or -std=C++11 is specified.

Sorry for the alternate proposal @sylveon, I thought it would be faster/easier to propose and show some code rather than discuss my proposed changes in your PR..