### PR TITLE
Accept std::string_view in Writer/PrettyWriter

### DIFF
--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -118,6 +118,11 @@ public:
     bool String(const std::basic_string<Ch>& str) {
         return String(str.data(), SizeType(str.size()));
     }
+#if __cplusplus >= 201703L
+    bool String(std::basic_string_view<Ch> str) {
+        return String(str.data(), SizeType(str.size()));
+    }
+#endif
 #endif
 
     bool StartObject() {
@@ -132,6 +137,11 @@ public:
     bool Key(const std::basic_string<Ch>& str) {
         return Key(str.data(), SizeType(str.size()));
     }
+#if __cplusplus >= 201703L
+    bool Key(std::basic_string_view<Ch> str) {
+        return Key(str.data(), SizeType(str.size()));
+    }
+#endif
 #endif
 	
     bool EndObject(SizeType memberCount = 0) {

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -160,6 +160,9 @@
 
 #if RAPIDJSON_HAS_STDSTRING
 #include <string>
+#if __cplusplus >= 201703L
+#include <string_view>
+#endif
 #endif // RAPIDJSON_HAS_STDSTRING
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -211,6 +211,11 @@ public:
     bool String(const std::basic_string<Ch>& str) {
         return String(str.data(), SizeType(str.size()));
     }
+#if __cplusplus >= 201703L
+    bool String(std::basic_string_view<Ch> str) {
+        return String(str.data(), SizeType(str.size()));
+    }
+#endif
 #endif
 
     bool StartObject() {
@@ -226,6 +231,11 @@ public:
     {
       return Key(str.data(), SizeType(str.size()));
     }
+#if __cplusplus >= 201703L
+    bool Key(std::basic_string_view<Ch> str) {
+        return Key(str.data(), SizeType(str.size()));
+    }
+#endif
 #endif
 
     bool EndObject(SizeType memberCount = 0) {

--- a/test/unittest/prettywritertest.cpp
+++ b/test/unittest/prettywritertest.cpp
@@ -121,6 +121,16 @@ TEST(PrettyWriter, String_STDSTRING) {
     EXPECT_TRUE(writer.EndArray());
     EXPECT_STREQ("[\n    \"Hello\\n\"\n]", buffer.GetString());
 }
+#if __cplusplus >= 201703L
+TEST(PrettyWriter, String_STDSTRING) {
+    StringBuffer buffer;
+    PrettyWriter<StringBuffer> writer(buffer);
+    EXPECT_TRUE(writer.StartArray());
+    EXPECT_TRUE(writer.String(std::string_view("Hello\n")));
+    EXPECT_TRUE(writer.EndArray());
+    EXPECT_STREQ("[\n    \"Hello\\n\"\n]", buffer.GetString());
+}
+#endif
 #endif
 
 #include <sstream>

--- a/test/unittest/writertest.cpp
+++ b/test/unittest/writertest.cpp
@@ -97,6 +97,14 @@ TEST(Writer, String) {
         writer.String(std::string("Hello\n"));
         EXPECT_STREQ("\"Hello\\n\"", buffer.GetString());
     }
+#if __cplusplus >= 201703L
+    {
+        StringBuffer buffer;
+        Writer<StringBuffer> writer(buffer);
+        writer.String(std::string_view("Hello\n"));
+        EXPECT_STREQ("\"Hello\\n\"", buffer.GetString());
+    }
+#endif
 #endif
 }
 


### PR DESCRIPTION
I'm evaluating rapidjson for project in which we make use of std::string_view, and noticed that the String() and Key() methods in the Writer/PrettyWriter templates do not accept it. This means that implicitly, my std::string_view instances will first be converted to new std::string when calling these functions.

One workaround would be to always call with this form:
```cpp
std::string_view str("Test");
writer.String(sv.data(), sv.size());
``` 
but this is easy to forget about and unnecessary with a trivial patch.

This simply adds support for `String(std::basic_string_view<Ch>)` and `Key(std::basic_string_view<Ch>)` if supported by the compiler.  General consensus seems to be that string_view should be passed by value, so I've done it that way.