### PR TITLE
add a workaround for GetObject macro defined by windows.h

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -42,6 +42,15 @@ RAPIDJSON_DIAG_OFF(4244) // conversion from kXxxFlags to 'uint16_t', possible lo
 RAPIDJSON_DIAG_OFF(effc++)
 #endif // __GNUC__
 
+#ifdef GetObject
+// see https://github.com/Tencent/rapidjson/issues/1448
+// a former included windows.h might have defined a macro called GetObject, which affects
+// GetObject defined here. This ensures the macro does not get applied
+#pragma push_macro("GetObject")
+#define RAPIDJSON_WINDOWS_GETOBJECT_WORKAROUND_APPLIED
+#undef GetObject
+#endif
+
 #ifndef RAPIDJSON_NOMEMBERITERATORCLASS
 #include <iterator> // std::random_access_iterator_tag
 #endif
@@ -1602,7 +1611,9 @@ public:
     }
 
     Object GetObject() { RAPIDJSON_ASSERT(IsObject()); return Object(*this); }
+    Object GetObj() { RAPIDJSON_ASSERT(IsObject()); return Object(*this); }
     ConstObject GetObject() const { RAPIDJSON_ASSERT(IsObject()); return ConstObject(*this); }
+    ConstObject GetObj() const { RAPIDJSON_ASSERT(IsObject()); return ConstObject(*this); }
 
     //@}
 
@@ -3007,5 +3018,10 @@ private:
 
 RAPIDJSON_NAMESPACE_END
 RAPIDJSON_DIAG_POP
+
+#ifdef RAPIDJSON_WINDOWS_GETOBJECT_WORKAROUND_APPLIED
+#pragma pop_macro("GetObject")
+#undef RAPIDJSON_WINDOWS_GETOBJECT_WORKAROUND_APPLIED
+#endif
 
 #endif // RAPIDJSON_DOCUMENT_H_

--- a/test/unittest/CMakeLists.txt
+++ b/test/unittest/CMakeLists.txt
@@ -16,6 +16,7 @@ set(UNITTEST_SOURCES
     jsoncheckertest.cpp
     namespacetest.cpp
     pointertest.cpp
+    platformtest.cpp
     prettywritertest.cpp
     ostreamwrappertest.cpp
     readertest.cpp

--- a/test/unittest/platformtest.cpp
+++ b/test/unittest/platformtest.cpp
@@ -1,0 +1,37 @@
+// Tencent is pleased to support the open source community by making RapidJSON available.
+// 
+// Copyright (C) 2021 THL A29 Limited, a Tencent company, and Milo Yip.
+//
+// Licensed under the MIT License (the "License"); you may not use this file except
+// in compliance with the License. You may obtain a copy of the License at
+//
+// http://opensource.org/licenses/MIT
+//
+// Unless required by applicable law or agreed to in writing, software distributed 
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+// CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+// specific language governing permissions and limitations under the License.
+
+#include "unittest.h"
+
+// see https://github.com/Tencent/rapidjson/issues/1448
+// including windows.h on purpose to provoke a compile time problem as GetObject is a 
+// macro that gets defined when windows.h is included
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include "rapidjson/document.h"
+
+using namespace rapidjson;
+
+TEST(Platform, GetObject) {
+    Document doc;
+    doc.Parse(" { \"object\" : { \"pi\": 3.1416} } ");
+    EXPECT_TRUE(doc.IsObject());
+    EXPECT_TRUE(doc.HasMember("object"));
+    const Document::ValueType& o = doc["object"];
+    EXPECT_TRUE(o.IsObject());
+    auto sub = o.GetObject();
+    EXPECT_TRUE(sub.HasMember("pi"));
+}

--- a/test/unittest/platformtest.cpp
+++ b/test/unittest/platformtest.cpp
@@ -22,6 +22,7 @@
 #endif
 
 #include "rapidjson/document.h"
+#undef GetObject
 
 using namespace rapidjson;
 
@@ -34,4 +35,6 @@ TEST(Platform, GetObject) {
     EXPECT_TRUE(o.IsObject());
     auto sub = o.GetObject();
     EXPECT_TRUE(sub.HasMember("pi"));
+    auto sub2 = o.GetObj();
+    EXPECT_TRUE(sub2.HasMember("pi"));
 }

--- a/test/unittest/platformtest.cpp
+++ b/test/unittest/platformtest.cpp
@@ -33,8 +33,8 @@ TEST(Platform, GetObject) {
     EXPECT_TRUE(doc.HasMember("object"));
     const Document::ValueType& o = doc["object"];
     EXPECT_TRUE(o.IsObject());
-    auto sub = o.GetObject();
+    Value::ConstObject sub = o.GetObject();
     EXPECT_TRUE(sub.HasMember("pi"));
-    auto sub2 = o.GetObj();
+    Value::ConstObject sub2 = o.GetObj();
     EXPECT_TRUE(sub2.HasMember("pi"));
 }


### PR DESCRIPTION
On windows a certain include order can break the build, because windows.h defines a macro GetObject
that redefines rapidjson's document GetObject API. This change ensures the macro does not get applied
to rapidjson's definition. For convenience 2 alias methods for GetObject, namely GetObj are added.

fixes #1448