### PR TITLE
Fix warnings with older GCC versions

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -24,6 +24,11 @@
 #include <type_traits>
 #endif
 
+#ifdef __GNUC__
+RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(effc++) // std::allocator can safely be inherited
+#endif
+
 RAPIDJSON_NAMESPACE_BEGIN
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -448,11 +453,6 @@ inline void Free(A& a, T *p, size_t n = 1)
 {
     static_cast<void>(Realloc<T, A>(a, p, n, 0));
 }
-
-#ifdef __GNUC__
-RAPIDJSON_DIAG_PUSH
-RAPIDJSON_DIAG_OFF(effc++) // std::allocator can safely be inherited
-#endif
 
 template <typename T, typename BaseAllocator = CrtAllocator>
 class StdAllocator :

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -52,6 +52,7 @@ RAPIDJSON_DIAG_OFF(4702)  // unreachable code
 #ifdef __GNUC__
 RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(effc++)
+RAPIDJSON_DIAG_OFF(type-limits)
 #endif
 
 //!@cond RAPIDJSON_HIDDEN_FROM_DOXYGEN

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -47,6 +47,11 @@ RAPIDJSON_DIAG_PUSH
 RAPIDJSON_DIAG_OFF(4127) // conditional expression is constant
 #endif
 
+#ifdef __GNUC__
+RAPIDJSON_DIAG_PUSH
+RAPIDJSON_DIAG_OFF(type-limits)
+#endif
+
 RAPIDJSON_NAMESPACE_BEGIN
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -704,6 +709,11 @@ inline bool Writer<StringBuffer>::ScanWriteUnescapedString(StringStream& is, siz
 RAPIDJSON_NAMESPACE_END
 
 #if defined(_MSC_VER) || defined(__clang__)
+RAPIDJSON_DIAG_POP
+#endif
+
+
+#ifdef __GNUC__
 RAPIDJSON_DIAG_POP
 #endif
 


### PR DESCRIPTION
```
/home/cameron/rapidjson/include/rapidjson/reader.h:1836:9: error: comparison is always true due to limited range of data type [-Werror=type-limits]
/home/cameron/rapidjson/include/rapidjson/reader.h:1014:17: error: comparison is always true due to limited range of data type [-Werror=type-limits]
/home/cameron/rapidjson/include/rapidjson/writer.h:431:18: error: comparison is always true due to limited range of data type [-Werror=type-limits]
/home/cameron/rapidjson/include/rapidjson/allocators.h:428:12: error: base class 'struct rapidjson::internal::BoolType<true>' has a non-virtual destructor [-Werror=effc++]
```