### PR TITLE
optimization when using network stream.

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -747,9 +747,11 @@ private:
         SkipWhitespaceAndComments<parseFlags>(is);
         RAPIDJSON_PARSE_ERROR_EARLY_RETURN_VOID;
 
-        if (Consume(is, '}')) {
+
+        if(RAPIDJSON_UNLIKELY(is.Peek() == '}')){
             if (RAPIDJSON_UNLIKELY(!handler.EndObject(0)))  // empty object
                 RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
+            is.Take();     
             return;
         }
 
@@ -784,9 +786,9 @@ private:
                     RAPIDJSON_PARSE_ERROR_EARLY_RETURN_VOID;
                     break;
                 case '}':
-                    is.Take();
                     if (RAPIDJSON_UNLIKELY(!handler.EndObject(memberCount)))
                         RAPIDJSON_PARSE_ERROR(kParseErrorTermination, is.Tell());
+                    is.Take();
                     return;
                 default:
                     RAPIDJSON_PARSE_ERROR(kParseErrorObjectMissCommaOrCurlyBracket, is.Tell()); break; // This useless break is only for making warning and coverage happy


### PR DESCRIPTION
我在用SAX风格解析 JSON网络流时，按照文档介绍的方法“使用者可以在另一线程解析 JSON，并通过阻塞输入流去暂停。”，我在stream.take()中阻塞。发现网络流已经接受了一个完整的JSON格式时，因为take()中的阻塞，reader.parse()并不能及时回调 bool EndObject(SizeType memberCount)。