### PR TITLE
Strong typing of enumerations

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1973,7 +1973,7 @@ private:
     template <typename, typename> friend class GenericValue;
     template <typename, typename, typename> friend class GenericDocument;
 
-    enum {
+    enum : uint32_t {
         kBoolFlag       = 0x0008,
         kNumberFlag     = 0x0010,
         kIntFlag        = 0x0020,

--- a/include/rapidjson/encodings.h
+++ b/include/rapidjson/encodings.h
@@ -600,7 +600,7 @@ struct ASCII {
 // AutoUTF
 
 //! Runtime-specified UTF encoding type of a stream.
-enum UTFType {
+enum UTFType : uint32_t {
     kUTF8 = 0,      //!< UTF-8.
     kUTF16LE = 1,   //!< UTF-16 little endian.
     kUTF16BE = 2,   //!< UTF-16 big endian.

--- a/include/rapidjson/error/error.h
+++ b/include/rapidjson/error/error.h
@@ -61,7 +61,7 @@ RAPIDJSON_NAMESPACE_BEGIN
 /*! \ingroup RAPIDJSON_ERRORS
     \see GenericReader::Parse, GenericReader::GetParseErrorCode
 */
-enum ParseErrorCode {
+enum ParseErrorCode : uint32_t {
     kParseErrorNone = 0,                        //!< No error.
 
     kParseErrorDocumentEmpty,                   //!< The document is empty.
@@ -159,7 +159,7 @@ typedef const RAPIDJSON_ERROR_CHARTYPE* (*GetParseErrorFunc)(ParseErrorCode);
 /*! \ingroup RAPIDJSON_ERRORS
     \see GenericSchemaValidator
 */
-enum ValidateErrorCode {
+enum ValidateErrorCode : int32_t {
     kValidateErrors    = -1,                   //!< Top level error code when kValidateContinueOnErrorsFlag set.
     kValidateErrorNone = 0,                    //!< No error.
 

--- a/include/rapidjson/pointer.h
+++ b/include/rapidjson/pointer.h
@@ -35,7 +35,7 @@ static const SizeType kPointerInvalidIndex = ~SizeType(0);  //!< Represents an i
 /*! \ingroup RAPIDJSON_ERRORS
     \see GenericPointer::GenericPointer, GenericPointer::GetParseErrorCode
 */
-enum PointerParseErrorCode {
+enum PointerParseErrorCode : uint32_t {
     kPointerParseErrorNone = 0,                     //!< The parse is successful
 
     kPointerParseErrorTokenMustBeginWithSolidus,    //!< A token must begin with a '/'

--- a/include/rapidjson/prettywriter.h
+++ b/include/rapidjson/prettywriter.h
@@ -32,7 +32,7 @@ RAPIDJSON_NAMESPACE_BEGIN
 //! Combination of PrettyWriter format flags.
 /*! \see PrettyWriter::SetFormatOptions
  */
-enum PrettyFormatOptions {
+enum PrettyFormatOptions : uint32_t {
     kFormatDefault = 0,         //!< Default pretty formatting.
     kFormatSingleLineArray = 1  //!< Format arrays on a single line.
 };

--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -726,7 +726,7 @@ RAPIDJSON_NAMESPACE_END
 RAPIDJSON_NAMESPACE_BEGIN
 
 //! Type of JSON value
-enum Type {
+enum Type : uint32_t {
     kNullType = 0,      //!< null
     kFalseType = 1,     //!< false
     kTrueType = 2,      //!< true

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -143,7 +143,7 @@ RAPIDJSON_NAMESPACE_BEGIN
 //! Combination of parseFlags
 /*! \see Reader::Parse, Document::Parse, Document::ParseInsitu, Document::ParseStream
  */
-enum ParseFlag {
+enum ParseFlag : uint32_t {
     kParseNoFlags = 0,              //!< No flags are set.
     kParseInsituFlag = 1,           //!< In-situ(destructive) parsing.
     kParseValidateEncodingFlag = 2, //!< Validate encoding of JSON strings.
@@ -1767,7 +1767,7 @@ private:
     // Iterative Parsing
 
     // States
-    enum IterativeParsingState {
+    enum IterativeParsingState : uint32_t {
         IterativeParsingFinishState = 0, // sink states at top
         IterativeParsingErrorState,      // sink states at top
         IterativeParsingStartState,
@@ -1795,7 +1795,7 @@ private:
     };
 
     // Tokens
-    enum Token {
+    enum Token : uint32_t {
         LeftBracketToken = 0,
         RightBracketToken,
 

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -139,7 +139,7 @@ RAPIDJSON_MULTILINEMACRO_END
 //! Combination of validate flags
 /*! \see
  */
-enum ValidateFlag {
+enum ValidateFlag : uint32_t {
     kValidateNoFlags = 0,                                       //!< No flags are set.
     kValidateContinueOnErrorFlag = 1,                           //!< Don't stop after first validation error.
     kValidateDefaultFlags = RAPIDJSON_VALIDATE_DEFAULT_FLAGS    //!< Default validate flags. Can be customized by defining RAPIDJSON_VALIDATE_DEFAULT_FLAGS
@@ -347,7 +347,7 @@ struct SchemaValidationContext {
     typedef typename SchemaType::ValueType ValueType;
     typedef typename ValueType::Ch Ch;
 
-    enum PatternValidatorType {
+    enum PatternValidatorType : uint32_t {
         kPatternValidatorOnly,
         kPatternValidatorWithProperty,
         kPatternValidatorWithAdditionalProperty
@@ -1171,7 +1171,7 @@ public:
 #undef RAPIDJSON_STRING_
 
 private:
-    enum SchemaValueType {
+    enum SchemaValueType : uint32_t {
         kNullSchemaType,
         kBooleanSchemaType,
         kObjectSchemaType,

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -63,7 +63,7 @@ RAPIDJSON_NAMESPACE_BEGIN
 #endif
 
 //! Combination of writeFlags
-enum WriteFlag {
+enum WriteFlag : uint32_t {
     kWriteNoFlags = 0,              //!< No flags are set.
     kWriteValidateEncodingFlag = 1, //!< Validate encoding of JSON strings.
     kWriteNanAndInfFlag = 2,        //!< Allow writing of Infinity, -Infinity and NaN.


### PR DESCRIPTION
For complete identity on all platforms and compilers, enums must be strongly typed. Otherwise, you can get various errors, for example, when calculating hash-sums of enumerations on different platforms - they may be not equal.