### PR TITLE
Fix the alignment of placement new buffer for GenericValue.

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1235,8 +1235,8 @@ public:
             // return NullValue;
 
             // Use static buffer and placement-new to prevent destruction
-            static char buffer[sizeof(GenericValue)];
-            return *new (buffer) GenericValue();
+            static GenericValid buffer;
+            return *new (reinterpret_cast<char *>(&buffer)) GenericValue();
         }
     }
     template <typename SourceAllocator>


### PR DESCRIPTION
When using operator[] on a GenericValue type clang-tidy complains,
appropriately, about the alignment of the buffer used for placement-new
of the "dummy" GenericValue.