### PR TITLE
Fix race condition in multi-thread environment

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1235,7 +1235,11 @@ public:
             // return NullValue;
 
             // Use static buffer and placement-new to prevent destruction
+#if defined(_MSC_VER) && _MSC_VER < 1900
+            __declspec(thread) static GenericValue buffer;
+#else
             thread_local static GenericValue buffer;
+#endif
             return *new (reinterpret_cast<char *>(&buffer)) GenericValue();
         }
     }

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1235,10 +1235,10 @@ public:
             // return NullValue;
 
             // Use static buffer and placement-new to prevent destruction
-#if defined(RAPIDJSON_HAS_CXX11)
-            thread_local static GenericValue buffer;
-#elif defined(_MSC_VER)
+#if defined(_MSC_VER) && _MSC_VER < 1900
             __declspec(thread) static GenericValue buffer;
+#elif defined(RAPIDJSON_HAS_CXX11)
+            thread_local static GenericValue buffer;
 #else
             __thread static GenericValue buffer;
 #endif

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1235,7 +1235,7 @@ public:
             // return NullValue;
 
             // Use static buffer and placement-new to prevent destruction
-            static GenericValue buffer;
+            thread_local static GenericValue buffer;
             return *new (reinterpret_cast<char *>(&buffer)) GenericValue();
         }
     }

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1236,13 +1236,16 @@ public:
 
             // Use static buffer and placement-new to prevent destruction
 #if defined(_MSC_VER) && _MSC_VER < 1900
-            __declspec(thread) static GenericValue buffer;
-#elif defined(RAPIDJSON_HAS_CXX11)
+            __declspec(thread) static char buffer[sizeof(GenericValue)];
+            return *new (buffer) GenericValue();
+#else
+#if defined(RAPIDJSON_HAS_CXX11)
             thread_local static GenericValue buffer;
 #else
             __thread static GenericValue buffer;
 #endif
             return *new (reinterpret_cast<char *>(&buffer)) GenericValue();
+#endif
         }
     }
     template <typename SourceAllocator>

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1235,10 +1235,12 @@ public:
             // return NullValue;
 
             // Use static buffer and placement-new to prevent destruction
-#if defined(_MSC_VER) && _MSC_VER < 1900
+#if defined(RAPIDJSON_HAS_CXX11)
+            thread_local static GenericValue buffer;
+#elif defined(_MSC_VER)
             __declspec(thread) static GenericValue buffer;
 #else
-            thread_local static GenericValue buffer;
+            __thread static GenericValue buffer;
 #endif
             return *new (reinterpret_cast<char *>(&buffer)) GenericValue();
         }


### PR DESCRIPTION
This PR fixes a potential race condition in `GenericValue::operator[]`. The original implementation can cause undefined behavior if `GenericValue::operator[]` is called by multiple threads simultaneously because they share the same memory space. This issue also applies to the case that they are different instances because `buffer` is `static` thus shared across the threads and instances boundary.

The simplest solution for this problem is to make `buffer` thread-local.

Related PR: #1989

@miloyip