### PR TITLE
gate definition of symmetric equality operators on impl, not lib

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1092,7 +1092,7 @@ public:
      */
     template <typename T> RAPIDJSON_DISABLEIF_RETURN((internal::IsGenericValue<T>), (bool)) operator!=(const T& rhs) const { return !(*this == rhs); }
 
-#ifndef __cpp_lib_three_way_comparison
+#ifndef __cpp_impl_three_way_comparison
     //! Equal-to operator with arbitrary types (symmetric version)
     /*! \return (rhs == lhs)
      */

--- a/test/unittest/simdtest.cpp
+++ b/test/unittest/simdtest.cpp
@@ -87,14 +87,12 @@ TEST(SIMD, SIMD_SUFFIX(SkipWhitespace_EncodedMemoryStream)) {
 
         MemoryStream ms(buffer, 1024);
         EncodedInputStream<UTF8<>, MemoryStream> s(ms);
-        size_t i = 0;
         for (;;) {
             SkipWhitespace(s);
             if (s.Peek() == '\0')
                 break;
             //EXPECT_EQ(i, s.Tell());
             EXPECT_EQ('X', s.Take());
-            i += step;
         }
     }
 }


### PR DESCRIPTION
These operators call themselves recursively if C++20 semantics are present in the compiler, regardless of standard library support for the operator; therefore the test should be on `__cpp_impl_three_way_comparison`, not `__cpp_lib_[...]`.

This fixes the `Value.EqualtoOperator` test when the language standard is set to C++20 and the standard library does not yet define the library support macro.

To demonstrate, with a reasonably recent clang and libc++ installed (and the gtest module checked out):
```
cmake -DCMAKE_CXX_FLAGS="-std=c++20 -stdlib=libc++ -lc++ -lc++abi -Wno-unused-command-line-argument" .
(make clean; make unittest; cd bin; ./unittest)
```
Prior to these changes, tests segfault in the test `Value.EqualtoOperator` because the operator at document.h:1099 calls itself with C++20's operator resolution semantics; it should not be defined even though libc++ does not yet define the feature test macro.

(This would also happen with a modern compiler on an older stdlib, if my understanding is correct.)