### PR TITLE
Access to allocator types

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -75,7 +75,7 @@ class GenericDocument;
     User can define this to use CrtAllocator or MemoryPoolAllocator.
 */
 #ifndef RAPIDJSON_DEFAULT_ALLOCATOR
-#define RAPIDJSON_DEFAULT_ALLOCATOR MemoryPoolAllocator<CrtAllocator>
+#define RAPIDJSON_DEFAULT_ALLOCATOR ::RAPIDJSON_NAMESPACE::MemoryPoolAllocator<::RAPIDJSON_NAMESPACE::CrtAllocator>
 #endif
 
 /*! \def RAPIDJSON_DEFAULT_STACK_ALLOCATOR

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -85,7 +85,7 @@ class GenericDocument;
     User can define this to use CrtAllocator or MemoryPoolAllocator.
 */
 #ifndef RAPIDJSON_DEFAULT_STACK_ALLOCATOR
-#define RAPIDJSON_DEFAULT_STACK_ALLOCATOR CrtAllocator
+#define RAPIDJSON_DEFAULT_STACK_ALLOCATOR ::RAPIDJSON_NAMESPACE::CrtAllocator
 #endif
 
 /*! \def RAPIDJSON_VALUE_DEFAULT_OBJECT_CAPACITY

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2486,6 +2486,7 @@ public:
     typedef typename Encoding::Ch Ch;                       //!< Character type derived from Encoding.
     typedef GenericValue<Encoding, Allocator> ValueType;    //!< Value type of the document.
     typedef Allocator AllocatorType;                        //!< Allocator type from template parameter.
+    typedef StackAllocator StackAllocatorType;              //!< StackAllocator type from template parameter.
 
     //! Constructor
     /*! Creates an empty document of specified type.


### PR DESCRIPTION
fix #2007

- Use `::RAPIDJSON_NAMESPACE::MemoryPoolAllocator<::RAPIDJSON_NAMESPACE::CrtAllocator>` instead of `MemoryPoolAllocator<CrtAllocator>` for `RAPIDJSON_DEFAULT_ALLOCATOR` to use it outsie of namespace `RAPIDJSON_NAMESPACE`.
- Use `::RAPIDJSON_NAMESPACE::CrtAllocator` instead of `CrtAllocator` for `RAPIDJSON_DEFAULT_STACK_ALLOCATOR` to use it outsie of namespace `RAPIDJSON_NAMESPACE`.
- Add `StackAllocatorType` for `GenericDocument` class template.