### PR TITLE
fix shadowed variable

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1459,7 +1459,7 @@ private:
     class NumberStream<InputStream, StackCharacter, true, true> : public NumberStream<InputStream, StackCharacter, true, false> {
         typedef NumberStream<InputStream, StackCharacter, true, false> Base;
     public:
-        NumberStream(GenericReader& reader, InputStream& is) : Base(reader, is) {}
+        NumberStream(GenericReader& reader, InputStream& s) : Base(reader, s) {}
 
         RAPIDJSON_FORCEINLINE Ch Take() { return Base::TakePush(); }
     };

--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1433,7 +1433,7 @@ private:
     class NumberStream<InputStream, StackCharacter, true, false> : public NumberStream<InputStream, StackCharacter, false, false> {
         typedef NumberStream<InputStream, StackCharacter, false, false> Base;
     public:
-        NumberStream(GenericReader& reader, InputStream& is) : Base(reader, is), stackStream(reader.stack_) {}
+        NumberStream(GenericReader& reader, InputStream& s) : Base(reader, s), stackStream(reader.stack_) {}
 
         RAPIDJSON_FORCEINLINE Ch TakePush() {
             stackStream.Put(static_cast<StackCharacter>(Base::is.Peek()));


### PR DESCRIPTION
A single character fix for:

error: declaration of ‘is’ shadows a member of ‘rapidjson::GenericReader<rapidjson::UTF8<>, rapidjson::UTF8<> >::NumberStream<rapidjson::GenericStringStream<rapidjson::UTF8<> >, true, false>’ [-Werror=shadow]