### PR TITLE
Avoid exit-time destructors.

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1235,8 +1235,8 @@ public:
             // return NullValue;
 
             // Use static buffer and placement-new to prevent destruction
-            static GenericValue buffer;
-            return *new (reinterpret_cast<char *>(&buffer)) GenericValue();
+            alignas(GenericValue) static char buffer[sizeof(GenericValue)];
+            return *new (buffer) GenericValue();
         }
     }
     template <typename SourceAllocator>

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1230,29 +1230,29 @@ public:
         else {
             RAPIDJSON_ASSERT(false);    // see above note
 
-            // Use thread-local storage to prevent races between threads.
-#if defined(_MSC_VER) && _MSC_VER < 1900
-// MSVC 2013 or earlier does not support `thread_local` attribute even in C++11
-// mode.
-#define RAPIDJSON_THREAD_LOCAL __declspec(thread)
-#elif RAPIDJSON_HAS_CXX11
-#define RAPIDJSON_THREAD_LOCAL thread_local
-#elif defined(__GNUC__) || defined(__clang__)
-#define RAPIDJSON_THREAD_LOCAL __thread
-#else
-#define RAPIDJSON_THREAD_LOCAL
-#endif
-
 #if RAPIDJSON_HAS_CXX11
-            // Use static buffer and placement-new to prevent destruction.
-            alignas(GenericValue) RAPIDJSON_THREAD_LOCAL static char buffer[sizeof(GenericValue)];
+            // Use thread-local storage to prevent races between threads.
+            // Use static buffer and placement-new to prevent destruction, with
+            // alignas() to ensure proper alignment.
+            alignas(GenericValue) thread_local static char buffer[sizeof(GenericValue)];
             return *new (buffer) GenericValue();
+#elif defined(_MSC_VER) && _MSC_VER < 1900
+            // There's no way to solve both thread locality and proper alignment
+            // simultaneously.
+            __declspec(thread) static char buffer[sizeof(GenericValue)];
+            return *new (buffer) GenericValue();
+#elif defined(__GNUC__) || defined(__clang__)
+            // This will generate -Wexit-time-destructors in clang, but that's
+            // better than having under-alignment.
+            __thread static GenericValue buffer;
+            return buffer;
 #else
-            // This will generate -Wexit-time-destructors in clang.
-            RAPIDJSON_THREAD_LOCAL static GenericValue buffer;
+            // Don't know what compiler this is, so don't know how to ensure
+            // thread-locality.
+            static GenericValue buffer;
             return buffer;
 #endif
-    }
+        }
     }
     template <typename SourceAllocator>
     const GenericValue& operator[](const GenericValue<Encoding, SourceAllocator>& name) const { return const_cast<GenericValue&>(*this)[name]; }

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1230,6 +1230,7 @@ public:
         else {
             RAPIDJSON_ASSERT(false);    // see above note
 
+#if defined(__cplusplus) && (__cplusplus >= 201103L)
             // This will generate -Wexit-time-destructors in clang
             // static GenericValue NullValue;
             // return NullValue;
@@ -1237,6 +1238,10 @@ public:
             // Use static buffer and placement-new to prevent destruction
             alignas(GenericValue) static char buffer[sizeof(GenericValue)];
             return *new (buffer) GenericValue();
+#else
+            static GenericValue buffer;
+            return *new (reinterpret_cast<char *>(&buffer)) GenericValue();
+#endif
         }
     }
     template <typename SourceAllocator>

--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -1230,19 +1230,29 @@ public:
         else {
             RAPIDJSON_ASSERT(false);    // see above note
 
-#if defined(__cplusplus) && (__cplusplus >= 201103L)
-            // This will generate -Wexit-time-destructors in clang
-            // static GenericValue NullValue;
-            // return NullValue;
+            // Use thread-local storage to prevent races between threads.
+#if defined(_MSC_VER) && _MSC_VER < 1900
+// MSVC 2013 or earlier does not support `thread_local` attribute even in C++11
+// mode.
+#define RAPIDJSON_THREAD_LOCAL __declspec(thread)
+#elif RAPIDJSON_HAS_CXX11
+#define RAPIDJSON_THREAD_LOCAL thread_local
+#elif defined(__GNUC__) || defined(__clang__)
+#define RAPIDJSON_THREAD_LOCAL __thread
+#else
+#define RAPIDJSON_THREAD_LOCAL
+#endif
 
-            // Use static buffer and placement-new to prevent destruction
-            alignas(GenericValue) static char buffer[sizeof(GenericValue)];
+#if RAPIDJSON_HAS_CXX11
+            // Use static buffer and placement-new to prevent destruction.
+            alignas(GenericValue) RAPIDJSON_THREAD_LOCAL static char buffer[sizeof(GenericValue)];
             return *new (buffer) GenericValue();
 #else
-            static GenericValue buffer;
-            return *new (reinterpret_cast<char *>(&buffer)) GenericValue();
+            // This will generate -Wexit-time-destructors in clang.
+            RAPIDJSON_THREAD_LOCAL static GenericValue buffer;
+            return buffer;
 #endif
-        }
+    }
     }
     template <typename SourceAllocator>
     const GenericValue& operator[](const GenericValue<Encoding, SourceAllocator>& name) const { return const_cast<GenericValue&>(*this)[name]; }


### PR DESCRIPTION
operator[]() was recently changed to use the existing code in order to
correctly align the returned pointer; however this broke
-Wexit-time-destructors.  Change to a method that is still correctly
aligned but does not generate a destructor.