### PR TITLE
Fix deprecation warnings in gtest submodule

### DIFF
--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -1399,12 +1399,12 @@ public:
   WIStreamWrapper(std::wistream& is) : is_(is) {}
 
   Ch Peek() const {
-    unsigned c = is_.peek();
+    wint_t c = is_.peek();
     return c == std::char_traits<wchar_t>::eof() ? Ch('\0') : static_cast<Ch>(c);
   }
 
   Ch Take() {
-    unsigned c = is_.get();
+    wint_t c = is_.get();
     return c == std::char_traits<wchar_t>::eof() ? Ch('\0') : static_cast<Ch>(c);
   }
 


### PR DESCRIPTION
Fix for #1815. Additionally, this fixes an implicit unsignedness warning in a test.