### PR TITLE
docs: fix simple typo, perecent -> percent

### DIFF
--- a/test/unittest/pointertest.cpp
+++ b/test/unittest/pointertest.cpp
@@ -303,7 +303,7 @@ TEST(Pointer, Parse_URIFragment) {
     }
 
     {
-        // Decode UTF-8 perecent encoding to UTF-8
+        // Decode UTF-8 percent encoding to UTF-8
         Pointer p("#/%C2%A2");
         EXPECT_TRUE(p.IsValid());
         EXPECT_EQ(1u, p.GetTokenCount());
@@ -311,7 +311,7 @@ TEST(Pointer, Parse_URIFragment) {
     }
 
     {
-        // Decode UTF-8 perecent encoding to UTF-16
+        // Decode UTF-8 percent encoding to UTF-16
         GenericPointer<GenericValue<UTF16<> > > p(L"#/%C2%A2");
         EXPECT_TRUE(p.IsValid());
         EXPECT_EQ(1u, p.GetTokenCount());
@@ -320,7 +320,7 @@ TEST(Pointer, Parse_URIFragment) {
     }
 
     {
-        // Decode UTF-8 perecent encoding to UTF-16
+        // Decode UTF-8 percent encoding to UTF-16
         GenericPointer<GenericValue<UTF16<> > > p(L"#/%E2%82%AC");
         EXPECT_TRUE(p.IsValid());
         EXPECT_EQ(1u, p.GetTokenCount());


### PR DESCRIPTION
There is a small typo in test/unittest/pointertest.cpp.

Should read `percent` rather than `perecent`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md