### PR TITLE
Compile errors on SLES/SLED 11.0 compiler

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -19,6 +19,7 @@
 #include "internal/meta.h"
 
 #include <memory>
+#include <limits>
 
 #if RAPIDJSON_HAS_CXX11
 #include <type_traits>
@@ -433,7 +434,7 @@ namespace internal {
 template<typename T, typename A>
 inline T* Realloc(A& a, T* old_p, size_t old_n, size_t new_n)
 {
-    RAPIDJSON_NOEXCEPT_ASSERT(old_n <= SIZE_MAX / sizeof(T) && new_n <= SIZE_MAX / sizeof(T));
+    RAPIDJSON_NOEXCEPT_ASSERT(old_n <= std::numeric_limits<size_t>::max() / sizeof(T) && new_n <= std::numeric_limits<size_t>::max() / sizeof(T));
     return static_cast<T*>(a.Realloc(old_p, old_n * sizeof(T), new_n * sizeof(T)));
 }
 

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -58,11 +58,11 @@ inline int CountDecimalDigit32(uint32_t n) {
 }
 
 inline void DigitGen(const DiyFp& W, const DiyFp& Mp, uint64_t delta, char* buffer, int* len, int* K) {
-    static const uint64_t kPow10[] = { 1U, 10U, 100U, 1000U, 10000U, 100000U, 1000000U, 10000000U, 100000000U,
-                                       1000000000U, 10000000000U, 100000000000U, 1000000000000U,
-                                       10000000000000U, 100000000000000U, 1000000000000000U,
-                                       10000000000000000U, 100000000000000000U, 1000000000000000000U,
-                                       10000000000000000000U };
+    static const uint64_t kPow10[] = { 1ULL, 10ULL, 100ULL, 1000ULL, 10000ULL, 100000ULL, 1000000ULL, 10000000ULL, 100000000ULL,
+                                       1000000000ULL, 10000000000ULL, 100000000000ULL, 1000000000000ULL,
+                                       10000000000000ULL, 100000000000000ULL, 1000000000000000ULL,
+                                       10000000000000000ULL, 100000000000000000ULL, 1000000000000000000ULL,
+                                       10000000000000000000ULL };
     const DiyFp one(uint64_t(1) << -Mp.e, Mp.e);
     const DiyFp wp_w = Mp - W;
     uint32_t p1 = static_cast<uint32_t>(Mp.f >> -one.e);


### PR DESCRIPTION
These were minor fixes to code that I believe need to be committed and are safe to commit.

include/rapidjson/internal/dtoa.h

in DigitGen function, use ULL suffix to uint64_t numeric constants

	    static const uint64_t kPow10[] = { 1ULL, 10ULL, 100ULL, 1000ULL, 10000ULL, 100000ULL, 1000000ULL, 10000000ULL, 100000000ULL,
                                       1000000000ULL, 10000000000ULL, 100000000000ULL, 1000000000000ULL,
                                       10000000000000ULL, 100000000000000ULL, 1000000000000000ULL,
                                       10000000000000000ULL, 100000000000000000ULL, 1000000000000000000ULL,
                                       10000000000000000000ULL };

include/rapidjson/allocators.h

#include <limits>
...

template<typename T, typename A>
inline T* Realloc(A& a, T* old_p, size_t old_n, size_t new_n)
{
    //RAPIDJSON_NOEXCEPT_ASSERT(old_n <= SIZE_MAX / sizeof(T) && new_n <= SIZE_MAX / sizeof(T));
    RAPIDJSON_NOEXCEPT_ASSERT(old_n <= std::numeric_limits<size_t>::max() / sizeof(T) && new_n <= std::numeric_limits<size_t>::max() / sizeof(T));
    return static_cast<T*>(a.Realloc(old_p, old_n * sizeof(T), new_n * sizeof(T)));
}

The other alternative to this code change would be the following.
It's likely that some header defined __STDC_LIMIT_MACROS and __STDC_CONSTANT_MACROS before stdint.h was included.
Compiling on Linux with g++ -D__STDC_LIMIT_MACROS -D__STDC_CONSTANT_MACROS a.cpp should fix this issue on the older compilers.


There are other areas of code that need fixing to compile with SLES/SLED 11.0 compiler.

On line 1247 in Document.h, I had to make this manual change.

template <typename SourceAllocator>
GenericValue& operator[](const GenericValue<Encoding, SourceAllocator>& name) {
    ...
#elif defined(__GNUC__) || defined(__clang__)
            // This will generate -Wexit-time-destructors in clang, but that's
            // better than having under-alignment.
            //__thread static GenericValue buffer;  
	   static GenericValue buffer;  // 2022-08-19 JWW
            return buffer;
   	   
but I cannot commit this change as it would effect others on different compilers. I do not know the correct fix for this, except by what I did. The #elif statement needs an additional test to it.
 
 There is one other error that needs fixing to compile on SLES/SLED 11.0.
 
I also had to use -fpermissive compiler option as well to get rid of this error:
"cannot begin a template-argument list"

I would like to be able to compile without using -fpermissive

Somewhere in the code, a template construct needs to be re-written as older compilers are more restrictive. Later compilers relaxed that constraint.

Solution: Add a whitespace between < and :

Currently, compiling using these compiler options to build an executable.

cd rapidjson-master
g++ -Wall -m32 -ggdb -Iinclude -O1 -fpermissive ./example/simpledom/simpledom.cpp -o simpledom 2>&1 | tee out.txt
   	 
   	 
    	 