### PR TITLE
[llvm-12 build fix] Homogenize typedefs in document.h

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -2482,7 +2482,7 @@ private:
 };
 
 //! GenericValue with UTF8 encoding
-typedef GenericValue<UTF8<> > Value;
+typedef GenericValue<UTF8<char>, MemoryPoolAllocator<CrtAllocator> > Value;
 
 ///////////////////////////////////////////////////////////////////////////////
 // GenericDocument 
@@ -2886,7 +2886,7 @@ private:
 };
 
 //! GenericDocument with UTF8 encoding
-typedef GenericDocument<UTF8<> > Document;
+typedef GenericDocument<UTF8<char>, MemoryPoolAllocator<CrtAllocator>, CrtAllocator> Document;
 
 
 //! Helper class for accessing Value of array type.


### PR DESCRIPTION
Adapted typedefs in `document.h` to correspond to declarations in `fwd.h`. Fixes https://github.com/Tencent/rapidjson/issues/2086