### PR TITLE
fix a typo in error.h: literial -> literal

### DIFF
--- a/include/rapidjson/error/error.h
+++ b/include/rapidjson/error/error.h
@@ -42,7 +42,7 @@ RAPIDJSON_DIAG_OFF(padded)
 ///////////////////////////////////////////////////////////////////////////////
 // RAPIDJSON_ERROR_STRING
 
-//! Macro for converting string literial to \ref RAPIDJSON_ERROR_CHARTYPE[].
+//! Macro for converting string literal to \ref RAPIDJSON_ERROR_CHARTYPE[].
 /*! \ingroup RAPIDJSON_ERRORS
     By default this conversion macro does nothing.
     On Windows, user can define this macro as \c _T(x) for supporting both


### PR DESCRIPTION
#2109 
In `/include/rapidjson/error/error.h`
A small typo: `literial` -> `literal`