### PR TITLE
Fix MSVC warning without NOMINMAX defined.

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -434,7 +434,7 @@ namespace internal {
 template<typename T, typename A>
 inline T* Realloc(A& a, T* old_p, size_t old_n, size_t new_n)
 {
-    RAPIDJSON_NOEXCEPT_ASSERT(old_n <= std::numeric_limits<size_t>::max() / sizeof(T) && new_n <= std::numeric_limits<size_t>::max() / sizeof(T));
+    RAPIDJSON_NOEXCEPT_ASSERT(old_n <= (std::numeric_limits<size_t>::max)() / sizeof(T) && new_n <= (std::numeric_limits<size_t>::max)() / sizeof(T));
     return static_cast<T*>(a.Realloc(old_p, old_n * sizeof(T), new_n * sizeof(T)));
 }
 


### PR DESCRIPTION
Fix MSVC warning without NOMINMAX defined.