### PR TITLE
fixed clang-tidy findings

### DIFF
--- a/include/rapidjson/document.h
+++ b/include/rapidjson/document.h
@@ -749,7 +749,7 @@ public:
                 GenericValue* le = reinterpret_cast<GenericValue*>(allocator.Malloc(count * sizeof(GenericValue)));
                 const GenericValue<Encoding,SourceAllocator>* re = rhs.GetElementsPointer();
                 for (SizeType i = 0; i < count; i++)
-                    new (&le[i]) GenericValue(re[i], allocator, copyConstStrings);
+                    new (&le[i]) GenericValue(re[i], allocator, copyConstStrings); // NOLINT(clang-analyzer-cplusplus.PlacementNew)
                 data_.f.flags = kArrayFlag;
                 data_.a.size = data_.a.capacity = count;
                 SetElementsPointer(le);

--- a/include/rapidjson/internal/dtoa.h
+++ b/include/rapidjson/internal/dtoa.h
@@ -33,6 +33,7 @@ RAPIDJSON_DIAG_OFF(array-bounds) // some gcc versions generate wrong warnings ht
 #endif
 
 inline void GrisuRound(char* buffer, int len, uint64_t delta, uint64_t rest, uint64_t ten_kappa, uint64_t wp_w) {
+    RAPIDJSON_ASSERT(len > 0);
     while (rest < wp_w && delta - rest >= ten_kappa &&
            (rest + ten_kappa < wp_w ||  /// closer
             wp_w - rest > rest + ten_kappa - wp_w)) {

--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -311,7 +311,7 @@ protected:
     }
 
     bool WriteInt(int i) {
-        char buffer[11];
+        char buffer[11]={0};
         const char* end = internal::i32toa(i, buffer);
         PutReserve(*os_, static_cast<size_t>(end - buffer));
         for (const char* p = buffer; p != end; ++p)
@@ -320,7 +320,7 @@ protected:
     }
 
     bool WriteUint(unsigned u) {
-        char buffer[10];
+        char buffer[10]={0};
         const char* end = internal::u32toa(u, buffer);
         PutReserve(*os_, static_cast<size_t>(end - buffer));
         for (const char* p = buffer; p != end; ++p)
@@ -329,7 +329,7 @@ protected:
     }
 
     bool WriteInt64(int64_t i64) {
-        char buffer[21];
+        char buffer[21]={0};
         const char* end = internal::i64toa(i64, buffer);
         PutReserve(*os_, static_cast<size_t>(end - buffer));
         for (const char* p = buffer; p != end; ++p)
@@ -338,7 +338,7 @@ protected:
     }
 
     bool WriteUint64(uint64_t u64) {
-        char buffer[20];
+        char buffer[20]={0};
         char* end = internal::u64toa(u64, buffer);
         PutReserve(*os_, static_cast<size_t>(end - buffer));
         for (char* p = buffer; p != end; ++p)
@@ -366,7 +366,7 @@ protected:
             return true;
         }
 
-        char buffer[25];
+        char buffer[25]={0};
         char* end = internal::dtoa(d, buffer, maxDecimalPlaces_);
         PutReserve(*os_, static_cast<size_t>(end - buffer));
         for (char* p = buffer; p != end; ++p)


### PR DESCRIPTION
Fixed clang-tidy findings
- uninitialized arrays
- array index out of bound (Ref: https://github.com/Tencent/rapidjson/issues/1812#issuecomment-813040315)

Ignored clang-tidy findings:
- clang-analyzer-cplusplus.PlacementNew