### PR TITLE
Remove empty cross-reference in comment

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -179,8 +179,6 @@ RAPIDJSON_MULTILINEMACRO_END
 #endif
 
 //! Combination of validate flags
-/*! \see
- */
 enum ValidateFlag {
     kValidateNoFlags = 0,                                       //!< No flags are set.
     kValidateContinueOnErrorFlag = 1,                           //!< Don't stop after first validation error.


### PR DESCRIPTION
Remove useless comment block which owns a '\see' cross-reference, but doesn't provide any data after it. This empty cross-reference triggers a compiler warning.

Change-Id: I5c01d57579e5efedcb4bf17b80b06db313a61ab3