### PR TITLE
Eliminate old style cast warning

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -2558,7 +2558,7 @@ public:
     //  If reporting all errors, the stack will be empty, so return "errors".
     const Ch* GetInvalidSchemaKeyword() const {
         if (!schemaStack_.Empty()) return CurrentContext().invalidKeyword;
-        if (GetContinueOnErrors() && !error_.ObjectEmpty()) return (const Ch*)GetErrorsString();
+        if (GetContinueOnErrors() && !error_.ObjectEmpty()) return static_cast<const Ch*>(GetErrorsString());
         return 0;
     }
 
@@ -2900,7 +2900,7 @@ public:
         ISchemaValidator* sv = new (GetStateAllocator().Malloc(sizeof(GenericSchemaValidator))) GenericSchemaValidator(*schemaDocument_, root, documentStack_.template Bottom<char>(), documentStack_.GetSize(),
         depth_ + 1,
         &GetStateAllocator());
-        sv->SetValidateFlags(inheritContinueOnErrors ? GetValidateFlags() : GetValidateFlags() & ~(unsigned)kValidateContinueOnErrorFlag);
+        sv->SetValidateFlags(inheritContinueOnErrors ? GetValidateFlags() : GetValidateFlags() & ~static_cast<unsigned>(kValidateContinueOnErrorFlag));
         return sv;
     }
 

--- a/test/unittest/allocatorstest.cpp
+++ b/test/unittest/allocatorstest.cpp
@@ -231,7 +231,7 @@ TEST(Allocator, MemoryPoolAllocator) {
     {
         a.Clear();
         const size_t bufSize = 1024;
-        char *buffer = (char *)a.Malloc(bufSize);
+        char *buffer = static_cast<char *>(a.Malloc(bufSize));
         MemoryPoolAllocator<> aligned_a(buffer, bufSize);
         EXPECT_TRUE(aligned_a.Capacity() > 0 && aligned_a.Capacity() <= bufSize);
         EXPECT_EQ(aligned_a.Size(), 0u);
@@ -243,7 +243,7 @@ TEST(Allocator, MemoryPoolAllocator) {
     {
         a.Clear();
         const size_t bufSize = 1024;
-        char *buffer = (char *)a.Malloc(bufSize);
+        char *buffer = static_cast<char *>(a.Malloc(bufSize));
         RAPIDJSON_ASSERT(bufSize % sizeof(void*) == 0);
         MemoryPoolAllocator<> unaligned_a(buffer + 1, bufSize - 1);
         EXPECT_TRUE(unaligned_a.Capacity() > 0 && unaligned_a.Capacity() <= bufSize - sizeof(void*));


### PR DESCRIPTION
Use static_cast to replace old style cast.

Change-Id: I30e659c8f2aadc02750555b0f041bfd2e1c8004a