### PR TITLE
Rename to fix allocator shadowing

### DIFF
--- a/include/rapidjson/allocators.h
+++ b/include/rapidjson/allocators.h
@@ -497,9 +497,9 @@ public:
 #endif
 
     /* implicit */
-    StdAllocator(const BaseAllocator& allocator) RAPIDJSON_NOEXCEPT :
+    StdAllocator(const BaseAllocator& baseAllocator) RAPIDJSON_NOEXCEPT :
         allocator_type(),
-        baseAllocator_(allocator)
+        baseAllocator_(baseAllocator)
     { }
 
     ~StdAllocator() RAPIDJSON_NOEXCEPT


### PR DESCRIPTION
The identifier 'allocator' in the RapidJSON StdAllocator class declaration shadows the identifier 'allocator' in the std::allocator class. To fix this, rename the 'allocator' identifier in the StdAllocator class declaration to a different name.