### PR TITLE
Fix MSVC build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ Doxyfile
 Doxyfile.zh-cn
 DartConfiguration.tcl
 *.nupkg
+/.vs
 
 # Files created by OS
 *.DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,11 @@ if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
+# MSVC runtime library flags
+if (POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 SET(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules)
 
 set(LIB_MAJOR_VERSION "1")
@@ -131,9 +136,7 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     add_definitions(-DNOMINMAX)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
     # CMake >= 3.10 should handle the above CMAKE_CXX_STANDARD fine, otherwise use /std:c++XX with MSVC >= 19.10
-    if (RAPIDJSON_BUILD_CXX11 AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.10")
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++11")
-    elseif (RAPIDJSON_BUILD_CXX17 AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.14")
+    if (RAPIDJSON_BUILD_CXX17 AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_LESS "19.14")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /std:c++17")
     endif()
     # Always compile with /WX

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -215,6 +215,7 @@ TEST(Document, Parse_Encoding) {
 TEST(Document, ParseStream_EncodedInputStream) {
     // UTF8 -> UTF16
     FILE* fp = OpenEncodedFile("utf8.json");
+    ASSERT_TRUE(fp != 0);
     char buffer[256];
     FileReadStream bis(fp, buffer, sizeof(buffer));
     EncodedInputStream<UTF8<>, FileReadStream> eis(bis);
@@ -242,6 +243,7 @@ TEST(Document, ParseStream_EncodedInputStream) {
 
     // Condense the original file and compare.
     fp = OpenEncodedFile("utf8.json");
+    ASSERT_TRUE(fp != 0);
     FileReadStream is(fp, buffer, sizeof(buffer));
     Reader reader;
     StringBuffer bos2;
@@ -256,6 +258,7 @@ TEST(Document, ParseStream_EncodedInputStream) {
 TEST(Document, ParseStream_AutoUTFInputStream) {
     // Any -> UTF8
     FILE* fp = OpenEncodedFile("utf32be.json");
+    ASSERT_TRUE(fp != 0);
     char buffer[256];
     FileReadStream bis(fp, buffer, sizeof(buffer));
     AutoUTFInputStream<unsigned, FileReadStream> eis(bis);
@@ -279,6 +282,7 @@ TEST(Document, ParseStream_AutoUTFInputStream) {
 
     // Condense the original file and compare.
     fp = OpenEncodedFile("utf8.json");
+    ASSERT_TRUE(fp != 0);
     FileReadStream is(fp, buffer, sizeof(buffer));
     Reader reader;
     StringBuffer bos2;


### PR DESCRIPTION
- Remove unsupported /std:c++11 flag (only c++14 and above is accepted)
- Enable MSVC runtime library flag based on CMP0091
- Ignore .vs folder
- Add extra assertions in file open tests to detect bad pointers