### PR TITLE
Fix: 'Stringify NaN, Inf as null'

### DIFF
--- a/include/rapidjson/writer.h
+++ b/include/rapidjson/writer.h
@@ -349,7 +349,7 @@ protected:
 
     bool WriteDouble(double d) {
         if (internal::Double(d).IsNanOrInf()) {
-            if (!(writeFlags & kWriteNanAndInfFlag))
+            if (!(writeFlags & kWriteNanAndInfFlag) && !(writeFlags & kWriteNanAndInfNullFlag))
                 return false;
             if (writeFlags & kWriteNanAndInfNullFlag) {
                 PutReserve(*os_, 4);


### PR DESCRIPTION
The code path where 'null' is written was never reached when 'writeFlags == kWriteNanAndInfNullFlag'