### PR TITLE
Fix object hashing in schema

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -407,7 +407,7 @@ private:
     
     bool WriteBuffer(Type type, const void* data, size_t len) {
         // FNV-1a from http://isthe.com/chongo/tech/comp/fnv/
-        uint64_t h = Hash(RAPIDJSON_UINT64_C2(0x84222325, 0xcbf29ce4), type);
+        uint64_t h = Hash(RAPIDJSON_UINT64_C2(0xcbf29ce4, 0x84222325), type);
         const unsigned char* d = static_cast<const unsigned char*>(data);
         for (size_t i = 0; i < len; i++)
             h = Hash(h, d[i]);

--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -367,7 +367,9 @@ public:
         uint64_t h = Hash(0, kObjectType);
         uint64_t* kv = stack_.template Pop<uint64_t>(memberCount * 2);
         for (SizeType i = 0; i < memberCount; i++)
-            h ^= Hash(kv[i * 2], kv[i * 2 + 1]);  // Use xor to achieve member order insensitive
+            // Issue #2205
+            // Hasing the key to avoid key=value cases with bug-prone zero-value hash
+            h ^= Hash(Hash(0, kv[i * 2]), kv[i * 2 + 1]);  // Use xor to achieve member order insensitive
         *stack_.template Push<uint64_t>() = h;
         return true;
     }

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -99,6 +99,9 @@ TEST(SchemaValidator, Hasher) {
     TEST_HASHER("{\"a\":1}", "{\"a\":1}", true);
     TEST_HASHER("{\"a\":1}", "{\"b\":1}", false);
     TEST_HASHER("{\"a\":1}", "{\"a\":2}", false);
+    TEST_HASHER("{\"a\":\"a\"}", "{\"b\":\"b\"}", false); // Key equals value hashing
+    TEST_HASHER("{\"a\":\"a\", \"b\":\"b\"}", "{\"c\":\"c\", \"d\":\"d\"}", false);
+    TEST_HASHER("{\"a\":\"a\"}", "{\"b\":\"b\", \"c\":\"c\"}", false);
     TEST_HASHER("{\"a\":1, \"b\":2}", "{\"b\":2, \"a\":1}", true); // Member order insensitive
     TEST_HASHER("{}", "null", false);
     TEST_HASHER("{}", "false", false);


### PR DESCRIPTION
The objects with key-value pairs where key=value will always produce zero-value hash.
The algorithm used for keys and string values is the same, so `Hasher::Hash` called on them in `Hasher::EndObject` will produce zero-value, due to xoring in FNV-1a algorithm. Such hash is bug-prone and easy to duplicate, for example: objects
```json
{"value": "value"}
```
and
```json
{"value1": "value1", "value2": "value2" }
```
will produce same hash: `0`

Fixes #2205, fixes #1558