### PR TITLE
Fix shadow warning

### DIFF
--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -2649,7 +2649,7 @@ TEST(SchemaValidator, Ref_remote_issue1210) {
         }
 
         public:
-          SchemaDocumentProvider(SchemaDocument** collection) : collection(collection) { }
+          SchemaDocumentProvider(SchemaDocument** documentCollection) : collection(documentCollection) { }
           virtual const SchemaDocument* GetRemoteDocument(const char* uri, SizeType length) {
             int i = 0;
             while (collection[i] && SchemaDocument::GValue(uri, length) != collection[i]->GetURI()) ++i;


### PR DESCRIPTION
Rename the parameter of the constructor 'SchemaDocumentProvider' from 'collection' to 'documentCollection', which has the same name with the member variable to fix the shadow warning.