### PR TITLE
Fix operatorEqVarError warning

### DIFF
--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -2645,6 +2645,7 @@ TEST(SchemaValidator, Ref_remote_issue1210) {
         SchemaDocumentProvider(const SchemaDocumentProvider&) : collection(NULL) {
         }
         SchemaDocumentProvider& operator=(const SchemaDocumentProvider&) {
+            collection = NULL;
             return *this;
         }
 


### PR DESCRIPTION
Assign SchemaDocumentProvider::collection to NULL in the operator= function to fix the operatorEqVarError warning.