### PR TITLE
fix: delete validator before clear

### DIFF
--- a/test/perftest/schematest.cpp
+++ b/test/perftest/schematest.cpp
@@ -205,12 +205,13 @@ TEST_F(Schema, TestSuite) {
     for (int i = 0; i < trialCount; i++) {
         for (TestSuiteList::const_iterator itr = testSuites.begin(); itr != testSuites.end(); ++itr) {
             const TestSuite& ts = **itr;
-            GenericSchemaValidator<SchemaDocument, BaseReaderHandler<UTF8<> >, MemoryPoolAllocator<> >  validator(*ts.schema, &validatorAllocator);
+            GenericSchemaValidator<SchemaDocument, BaseReaderHandler<UTF8<> >, MemoryPoolAllocator<>>  *validator = new GenericSchemaValidator<SchemaDocument, BaseReaderHandler<UTF8<> >, MemoryPoolAllocator<>>(*ts.schema, &validatorAllocator);
             for (DocumentList::const_iterator testItr = ts.tests.begin(); testItr != ts.tests.end(); ++testItr) {
-                validator.Reset();
-                (*testItr)->Accept(validator);
+                validator->Reset();
+                (*testItr)->Accept(*validator);
                 testCount++;
             }
+            delete validator;
             validatorAllocator.Clear();
         }
     }


### PR DESCRIPTION
Hi, we found an incorrect use of Clear API of the allocator, which leads to Use-After-Free in schematest.

At test/perftest/schematest.cpp:208, the validator is constructed with validatorAllocator, and the chunks allocated during line 210 to line 213 are collected by the Clear API at line 214 as the for statement is ended. 
However, the destructor of GeneriSchemaValidator is called at line 215, leading to invalid accesses to the chunks(Stack). 

To avoid this issue, I added explicit delete to the validator before the Clear API call.

Thank you very much for taking the time to revise this issue!
