### PR TITLE
Add argument for variadic macro

### DIFF
--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -461,7 +461,15 @@ struct DocumentMove: public ::testing::Test {
 };
 
 typedef ::testing::Types< CrtAllocator, MemoryPoolAllocator<> > MoveAllocatorTypes;
-TYPED_TEST_CASE(DocumentMove, MoveAllocatorTypes);
+class TypeTestNames {
+public:
+    template <typename T>
+    static std::string GetName(int) {
+        if (std::is_same<T, CrtAllocator>()) return "CrtAllocator";
+        if (std::is_same<T, MemoryPoolAllocator<>>()) return "MemoryPoolAllocator<>";
+    }
+};
+TYPED_TEST_CASE(DocumentMove, MoveAllocatorTypes, TypeTestNames);
 
 TYPED_TEST(DocumentMove, MoveConstructor) {
     typedef TypeParam Allocator;


### PR DESCRIPTION
To eliminate the warning for gnu-zero-variadic-macro-arguments, add an argument for the variadic macro argument in the TYPED_TEST_CASE macro call.

Replace TYPED_TEST_CASE with TYPED_TEST_SUITE because TYPED_TEST_CASE has been deprecated.