### PR TITLE
Ignore gnu-zero-variable-macro-arguments

### DIFF
--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -461,15 +461,7 @@ struct DocumentMove: public ::testing::Test {
 };
 
 typedef ::testing::Types< CrtAllocator, MemoryPoolAllocator<> > MoveAllocatorTypes;
-class TypeTestNames {
-public:
-    template <typename T>
-    static std::string GetName(int) {
-        if (std::is_same<T, CrtAllocator>()) return "CrtAllocator";
-        if (std::is_same<T, MemoryPoolAllocator<>>()) return "MemoryPoolAllocator<>";
-    }
-};
-TYPED_TEST_CASE(DocumentMove, MoveAllocatorTypes, TypeTestNames);
+TYPED_TEST_CASE(DocumentMove, MoveAllocatorTypes);
 
 TYPED_TEST(DocumentMove, MoveConstructor) {
     typedef TypeParam Allocator;

--- a/test/unittest/documenttest.cpp
+++ b/test/unittest/documenttest.cpp
@@ -461,7 +461,15 @@ struct DocumentMove: public ::testing::Test {
 };
 
 typedef ::testing::Types< CrtAllocator, MemoryPoolAllocator<> > MoveAllocatorTypes;
-TYPED_TEST_CASE(DocumentMove, MoveAllocatorTypes);
+class TypeTestNames {
+public:
+    template <typename T>
+    static std::string GetName(int) {
+        if (std::is_same<T, CrtAllocator>()) return "CrtAllocator";
+        if (std::is_same<T, MemoryPoolAllocator<>>()) return "MemoryPoolAllocator<>";
+    }
+};
+TYPED_TEST_CASE(DocumentMove, MoveAllocatorTypes, TypeTestNames);
 
 TYPED_TEST(DocumentMove, MoveConstructor) {
     typedef TypeParam Allocator;

--- a/test/unittest/unittest.h
+++ b/test/unittest/unittest.h
@@ -54,6 +54,7 @@
 #ifdef __clang__
 // All TEST() macro generated this warning, disable globally
 #pragma GCC diagnostic ignored "-Wglobal-constructors"
+#pragma clang diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #endif
 
 template <typename Ch>


### PR DESCRIPTION
Ignore gnu-zero-variadic-macro-arguments for clang because "__VA_ARGS__" is a GNU extension, not part of the standard C language.