### PR TITLE
Fix static_cast in regex.h

### DIFF
--- a/include/rapidjson/internal/regex.h
+++ b/include/rapidjson/internal/regex.h
@@ -615,7 +615,7 @@ public:
         RAPIDJSON_ASSERT(regex_.IsValid());
         if (!allocator_)
             ownAllocator_ = allocator_ = RAPIDJSON_NEW(Allocator)();
-        stateSet_ = static_cast<unsigned*>(allocator_->Malloc(GetStateSetSize()));
+        stateSet_ = static_cast<uint32_t*>(allocator_->Malloc(GetStateSetSize()));
         state0_.template Reserve<SizeType>(regex_.stateCount_);
         state1_.template Reserve<SizeType>(regex_.stateCount_);
     }


### PR DESCRIPTION
In the constructor for GenericRegexSearch, there was an issue with a static_cast casting the result of the Malloc call. The issue was that the stateSet_ member is of type uint32_t*, and there was an attempt to assign an unsigned* to it. On some systems, uint32_t is not equivalent to unsigned, thus yielding a compile error for assigning pointers of different type.