### PR TITLE
Add two type conversions in bigintegertest.cpp

### DIFF
--- a/test/unittest/bigintegertest.cpp
+++ b/test/unittest/bigintegertest.cpp
@@ -98,9 +98,9 @@ TEST(BigInteger, MultiplyUint32) {
     BigInteger c(123);
     c *= static_cast<uint32_t>(456u);
     EXPECT_TRUE(BigInteger(123u * 456u) == c);
-    c *= 0xFFFFFFFFu;
+    c *= static_cast<uint64_t>(0xFFFFFFFFu);
     EXPECT_TRUE(BIGINTEGER_LITERAL("240896125641960") == c);
-    c *= 0xFFFFFFFFu;
+    c *= static_cast<uint64_t>(0xFFFFFFFFu);
     EXPECT_TRUE(BIGINTEGER_LITERAL("1034640981124429079698200") == c);
 }
 


### PR DESCRIPTION
BigInteger& operator*= has two implementations, one for uint64_t, another for uint32_t.

Ambiguous overload occured in bigintegertest.cpp because the type of *= right value is not specified. Add two type conversions for the two values.