### PR TITLE
Fix inconsistent compile condition of two related macros

### DIFF
--- a/include/rapidjson/rapidjson.h
+++ b/include/rapidjson/rapidjson.h
@@ -333,7 +333,7 @@
 */
 #ifndef RAPIDJSON_48BITPOINTER_OPTIMIZATION
 #if defined(__amd64__) || defined(__amd64) || defined(__x86_64__) || defined(__x86_64) || defined(_M_X64) || defined(_M_AMD64)
-#define RAPIDJSON_48BITPOINTER_OPTIMIZATION 1
+#define RAPIDJSON_48BITPOINTER_OPTIMIZATION RAPIDJSON_64BIT
 #else
 #define RAPIDJSON_48BITPOINTER_OPTIMIZATION 0
 #endif


### PR DESCRIPTION
The compile conditions of RAPIDJSON_48BITPOINTER_OPTIMIZATION and RAPIDJSON_64BIT are different. But there will be an error when RAPIDJSON_48BITPOINTER_OPTIMIZATION = 1, RAPIDJSON_64BIT != 1.

Define RAPIDJSON_48BITPOINTER_OPTIMIZATION as RAPIDJSON_64BIT to fix this problem.

Issue: https://github.com/Tencent/rapidjson/issues/2281