### PR TITLE
Guard against max being macros in schema.h

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -1645,8 +1645,7 @@ private:
         double qRounded = std::floor(q + 0.5);
         double scaledEpsilon = (q + qRounded) * std::numeric_limits<double>::epsilon();
         double difference = std::abs(qRounded - q);
-        bool isMultiple = (difference <= scaledEpsilon)
-                                        || (difference < std::numeric_limits<double>::min());
+        bool isMultiple = difference <= scaledEpsilon || difference < (std::numeric_limits<double>::min)();
         if (!isMultiple) {
             context.error_handler.NotMultipleOf(d, multipleOf_);
             RAPIDJSON_INVALID_KEYWORD_RETURN(kValidateErrorMultipleOf);


### PR DESCRIPTION
Similar to:
**Issue** - https://github.com/Tencent/rapidjson/issues/1033 
**Solution** - https://github.com/Tencent/rapidjson/commit/6e38649ec61e5f4f382c257a6b27698bb55eff61

Fix `std::numeric_limits::max()` compilation confusion on Windows