### PR TITLE
Fix bug when parsing NaN, Inf with fraction or exponent parts (fixes …

### DIFF
--- a/include/rapidjson/reader.h
+++ b/include/rapidjson/reader.h
@@ -1584,7 +1584,7 @@ private:
         // Parse frac = decimal-point 1*DIGIT
         int expFrac = 0;
         size_t decimalPosition;
-        if (Consume(s, '.')) {
+        if (!useNanOrInf && Consume(s, '.')) {
             decimalPosition = s.Length();
 
             if (RAPIDJSON_UNLIKELY(!(s.Peek() >= '0' && s.Peek() <= '9')))
@@ -1631,7 +1631,7 @@ private:
 
         // Parse exp = e [ minus / plus ] 1*DIGIT
         int exp = 0;
-        if (Consume(s, 'e') || Consume(s, 'E')) {
+        if (!useNanOrInf && (Consume(s, 'e') || Consume(s, 'E'))) {
             if (!useDouble) {
                 d = static_cast<double>(use64bit ? i64 : i);
                 useDouble = true;

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -2338,6 +2338,9 @@ TEST(Reader, ParseNanAndInfinity) {
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-nan", 1u);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "NAN", 1u);
     TEST_NAN_INF_ERROR(kParseErrorValueInvalid, "-Infinty", 6u);
+    TEST_NAN_INF_ERROR(kParseErrorDocumentRootNotSingular, "NaN.2e2", 3u);
+    TEST_NAN_INF_ERROR(kParseErrorDocumentRootNotSingular, "Inf.2", 3u);
+    TEST_NAN_INF_ERROR(kParseErrorDocumentRootNotSingular, "-InfE2", 4u);
 
 #undef TEST_NAN_INF_ERROR
 #undef TEST_NAN_INF


### PR DESCRIPTION
…#2299)

This patch fixes the issue(#2299)  where parsing NaN or Inf values with fractional or exponent parts would return incorrect results (e.g., "NaN.2e2" would be parsed as 20).
Before this patch, the parser would continue to process the fractional and exponent parts even after successfully parsing a valid NaN or Inf, which could lead to parsing errors. This patch adds a check for such cases to skips the parsing of the fractional and exponent parts after completing the NaN and Inf parsing.