### PR TITLE
Fix out of bounds read with kParseValidateEncodingFlag

### DIFF
--- a/include/rapidjson/encodings.h
+++ b/include/rapidjson/encodings.h
@@ -177,10 +177,10 @@ struct UTF8 {
 
     template <typename InputStream, typename OutputStream>
     static bool Validate(InputStream& is, OutputStream& os) {
-#define RAPIDJSON_COPY() os.Put(c = is.Take())
+#define RAPIDJSON_COPY() if (c != '\0') os.Put(c = is.Take())
 #define RAPIDJSON_TRANS(mask) result &= ((GetRange(static_cast<unsigned char>(c)) & mask) != 0)
 #define RAPIDJSON_TAIL() RAPIDJSON_COPY(); RAPIDJSON_TRANS(0x70)
-        Ch c;
+        Ch c = static_cast<Ch>(-1);
         RAPIDJSON_COPY();
         if (!(c & 0x80))
             return true;

--- a/test/unittest/readertest.cpp
+++ b/test/unittest/readertest.cpp
@@ -987,6 +987,24 @@ TEST(Reader, ParseString_Error) {
         }
     }
 
+    // 3.6 Lonely start characters near the end of the input
+    {
+        char e[] = { '\"', 0, '\"', '\0' };
+        for (unsigned c = 0xC0u; c <= 0xFFu; c++) {
+            e[1] = static_cast<char>(c);
+            unsigned streamPos;
+            if (c <= 0xC1u)
+                streamPos = 2; // 0xC0 - 0xC1
+            else if (c <= 0xDFu)
+                streamPos = 3; // 0xC2 - 0xDF
+            else if (c <= 0xF4u)
+                streamPos = 4; // 0xE0 - 0xF4
+            else
+                streamPos = 2; // 0xF5 - 0xFF
+            TEST_STRING_ERROR(kParseErrorStringInvalidEncoding, e, 1u, streamPos);
+        }
+    }
+
     // 4  Overlong sequences
 
     // 4.1  Examples of an overlong ASCII character


### PR DESCRIPTION
This patch fixes out-of-bound reads while parsing JSONs with kParseValidateEncodingFlag options. Example of fuzzer report:


```
==8041==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x503000785364 at pc 0x55fb97222614 bp 0x7fff724547c0 sp 0x7fff724547b8
READ of size 1 at 0x503000785364 thread T0
    #0 0x55fb97222613 in rapidjson::GenericStringStream<rapidjson::UTF8<char>>::Take() rapidjson/include/rapidjson/stream.h:160:24
    #1 0x55fb972684b4 in bool rapidjson::UTF8<char>::Validate<rapidjson::GenericStringStream<rapidjson::UTF8<char>>, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>>(rapidjson::GenericStringStream<rapidjson::UTF8<char>>&, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>&) rapidjson/include/rapidjson/encodings.h:196:59
    #2 0x55fb97267b76 in bool rapidjson::Transcoder<rapidjson::UTF8<char>, rapidjson::UTF8<char>>::Validate<rapidjson::GenericStringStream<rapidjson::UTF8<char>>, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>>(rapidjson::GenericStringStream<rapidjson::UTF8<char>>&, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>&) rapidjson/include/rapidjson/encodings.h:706:16
    #3 0x55fb972678b5 in void rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::ParseStringToStream<2u, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::GenericStringStream<rapidjson::UTF8<char>>, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>>(rapidjson::GenericStringStream<rapidjson::UTF8<char>>&, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>&) rapidjson/include/rapidjson/reader.h:1062:21
    #4 0x55fb972622cb in void rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::ParseString<2u, rapidjson::GenericStringStream<rapidjson::UTF8<char>>, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>>(rapidjson::GenericStringStream<rapidjson::UTF8<char>>&, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>&, bool) rapidjson/include/rapidjson/reader.h:978:13
    #5 0x55fb972613e3 in void rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::ParseValue<2u, rapidjson::GenericStringStream<rapidjson::UTF8<char>>, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>>(rapidjson::GenericStringStream<rapidjson::UTF8<char>>&, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>&) rapidjson/include/rapidjson/reader.h:1757:23
    #6 0x55fb97260d33 in rapidjson::ParseResult rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::Parse<2u, rapidjson::GenericStringStream<rapidjson::UTF8<char>>, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>>(rapidjson::GenericStringStream<rapidjson::UTF8<char>>&, rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>&) rapidjson/include/rapidjson/reader.h:575:13
    #7 0x55fb9726053c in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>& rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::ParseStream<2u, rapidjson::UTF8<char>, rapidjson::GenericStringStream<rapidjson::UTF8<char>>>(rapidjson::GenericStringStream<rapidjson::UTF8<char>>&) rapidjson/include/rapidjson/document.h:2647:40
    #8 0x55fb9726026c in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>& rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::Parse<2u, rapidjson::UTF8<char>>(rapidjson::UTF8<char>::Ch const*) rapidjson/include/rapidjson/document.h:2712:16
    #9 0x55fb97260116 in rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>& rapidjson::GenericDocument<rapidjson::UTF8<char>, rapidjson::MemoryPoolAllocator<rapidjson::CrtAllocator>, rapidjson::CrtAllocator>::Parse<2u>(char const*) rapidjson/include/rapidjson/document.h:2721:16
    #10 0x55fb9721b398 in void fuzzWithFlags<2u>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>> const&) rapidjson/../../google/oss-fuzz/projects/rapidjson/fuzzer.cpp:30:42
    #11 0x55fb97218872 in LLVMFuzzerTestOneInput rapidjson/../../google/oss-fuzz/projects/rapidjson/fuzzer.cpp:55:5
    #12 0x55fb971248c0 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (fuzzer+0x628c0)
    #13 0x55fb97124035 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (fuzzer+0x62035)
    #14 0x55fb97125815 in fuzzer::Fuzzer::MutateAndTestOne() (fuzzer+0x63815)
    #15 0x55fb97126425 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (fuzzer+0x64425)
    #16 0x55fb9711458b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (fuzzer+0x5258b)
    #17 0x55fb9713d5c2 in main (fuzzer+0x7b5c2)
    #18 0x7f51d8abbd8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16
    #19 0x7f51d8abbe3f in __libc_start_main csu/../csu/libc-start.c:392:3
    #20 0x55fb971099f4 in _start (fuzzer+0x479f4)

0x503000785364 is located 0 bytes after 20-byte region [0x503000785350,0x503000785364)
allocated by thread T0 here:
    #0 0x55fb972162fd in operator new(unsigned long) (fuzzer+0x1542fd)
    #1 0x55fb9721d56e in std::__new_allocator<char>::allocate(unsigned long, void const*) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/new_allocator.h:147:27
    #2 0x55fb9721d3dc in std::allocator_traits<std::allocator<char>>::allocate(std::allocator<char>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/alloc_traits.h:482:20
    #3 0x55fb9721d3dc in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_S_allocate(std::allocator<char>&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:126:16
    #4 0x55fb9721cb75 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_create(unsigned long&, unsigned long) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.tcc:155:14
    #5 0x55fb9721c4e4 in void std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::_M_construct<unsigned char const*>(unsigned char const*, unsigned char const*, std::forward_iterator_tag) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.tcc:225:14
    #6 0x55fb97218c42 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>::basic_string<unsigned char const*, void>(unsigned char const*, unsigned char const*, std::allocator<char> const&) /usr/bin/../lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/basic_string.h:753:4
    #7 0x55fb9721876f in LLVMFuzzerTestOneInput rapidjson/../../google/oss-fuzz/projects/rapidjson/fuzzer.cpp:49:23
    #8 0x55fb971248c0 in fuzzer::Fuzzer::ExecuteCallback(unsigned char const*, unsigned long) (fuzzer+0x628c0)
    #9 0x55fb97124035 in fuzzer::Fuzzer::RunOne(unsigned char const*, unsigned long, bool, fuzzer::InputInfo*, bool, bool*) (fuzzer+0x62035)
    #10 0x55fb97125815 in fuzzer::Fuzzer::MutateAndTestOne() (fuzzer+0x63815)
    #11 0x55fb97126425 in fuzzer::Fuzzer::Loop(std::vector<fuzzer::SizedFile, std::allocator<fuzzer::SizedFile>>&) (fuzzer+0x64425)
    #12 0x55fb9711458b in fuzzer::FuzzerDriver(int*, char***, int (*)(unsigned char const*, unsigned long)) (fuzzer+0x5258b)
    #13 0x55fb9713d5c2 in main (fuzzer+0x7b5c2)
    #14 0x7f51d8abbd8f in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16

SUMMARY: AddressSanitizer: heap-buffer-overflow rapidjson/include/rapidjson/stream.h:160:24 in rapidjson::GenericStringStream<rapidjson::UTF8<char>>::Take()
Shadow bytes around the buggy address:
  0x503000785080: fd fd fd fd fa fa fd fd fd fd fa fa fd fd fd fa
  0x503000785100: fa fa fd fd fd fa fa fa fd fd fd fa fa fa fd fd
  0x503000785180: fd fa fa fa fd fd fd fa fa fa fd fd fd fd fa fa
  0x503000785200: fd fd fd fd fa fa fd fd fd fa fa fa fd fd fd fa
  0x503000785280: fa fa fd fd fd fa fa fa fd fd fd fa fa fa fd fd
=>0x503000785300: fd fa fa fa 00 00 03 fa fa fa 00 00[04]fa fa fa
  0x503000785380: fd fd fd fa fa fa fd fd fd fa fa fa fd fd fd fa
  0x503000785400: fa fa fd fd fd fa fa fa 00 00 00 fa fa fa fa fa
  0x503000785480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x503000785500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x503000785580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==8041==ABORTING
MS: 5 InsertByte-InsertByte-InsertRepeatedBytes-ChangeBit-EraseBytes-; base unit: 3d29a8122a6ca68b3a774a2eb1c77fb086276984
0x22,0x2e,0x32,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x2d,0x40,0xf0,
\".2--------------@\360
artifact_prefix='./'; Test unit written to ./crash-52b6c06fcc019194aa4e0734a055e6943593313b
Base64: Ii4yLS0tLS0tLS0tLS0tLS1A8A==
```

New unit tests were added. They are failing without the patch. With ASAN enabled:

```
=================================================================
==82872==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7f09a11d3af4 at pc 0x5577b18ed3d7 bp 0x7fff44e545b0 sp 0x7fff44e545a0
READ of size 1 at 0x7f09a11d3af4 thread T0
    #0 0x5577b18ed3d6 in rapidjson::GenericStringStream<rapidjson::UTF8<char> >::Take() rapidjson/include/rapidjson/stream.h:160
    #1 0x5577b1e2a99e in bool rapidjson::UTF8<char>::Validate<rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>&) rapidjson/include/rapidjson/encodings.h:196
    #2 0x5577b1e1c5bb in bool rapidjson::Transcoder<rapidjson::UTF8<char>, rapidjson::UTF8<char> >::Validate<rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>&) rapidjson/include/rapidjson/encodings.h:706
    #3 0x5577b1d97615 in void rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::ParseStringToStream<2u, rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::StackStream<char>&) (rapidjson/build/Bullettech/Debug/bin/unittest+0x5b2615) (BuildId: eea20f0c45e248ded253202f86e529ebdb50cb0e)
    #4 0x5577b1d20123 in void rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::ParseString<2u, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::BaseReaderHandler<rapidjson::UTF8<char>, void> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::BaseReaderHandler<rapidjson::UTF8<char>, void>&, bool) rapidjson/include/rapidjson/reader.h:978
    #5 0x5577b1d03282 in void rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::ParseValue<2u, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::BaseReaderHandler<rapidjson::UTF8<char>, void> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::BaseReaderHandler<rapidjson::UTF8<char>, void>&) rapidjson/include/rapidjson/reader.h:1757
    #6 0x5577b1ce453f in rapidjson::ParseResult rapidjson::GenericReader<rapidjson::UTF8<char>, rapidjson::UTF8<char>, rapidjson::CrtAllocator>::Parse<2u, rapidjson::GenericStringStream<rapidjson::UTF8<char> >, rapidjson::BaseReaderHandler<rapidjson::UTF8<char>, void> >(rapidjson::GenericStringStream<rapidjson::UTF8<char> >&, rapidjson::BaseReaderHandler<rapidjson::UTF8<char>, void>&) rapidjson/include/rapidjson/reader.h:575
    #7 0x5577b1b91ca0 in Reader_ParseString_Error_Test::TestBody() rapidjson/test/unittest/readertest.cpp:1004
    #8 0x5577b25ad960 in void testing::internal::HandleSehExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) rapidjson/thirdparty/gtest/googletest/src/gtest.cc:2418
    #9 0x5577b259e30e in void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) rapidjson/thirdparty/gtest/googletest/src/gtest.cc:2454
    #10 0x5577b254f363 in testing::Test::Run() rapidjson/thirdparty/gtest/googletest/src/gtest.cc:2492
    #11 0x5577b255083b in testing::TestInfo::Run() rapidjson/thirdparty/gtest/googletest/src/gtest.cc:2668
    #12 0x5577b25514b3 in testing::TestCase::Run() rapidjson/thirdparty/gtest/googletest/src/gtest.cc:2786
    #13 0x5577b256a7ea in testing::internal::UnitTestImpl::RunAllTests() rapidjson/thirdparty/gtest/googletest/src/gtest.cc:5048
    #14 0x5577b25b06f9 in bool testing::internal::HandleSehExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) rapidjson/thirdparty/gtest/googletest/src/gtest.cc:2418
    #15 0x5577b25a0c25 in bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) rapidjson/thirdparty/gtest/googletest/src/gtest.cc:2454
    #16 0x5577b256753a in testing::UnitTest::Run() rapidjson/thirdparty/gtest/googletest/src/gtest.cc:4664
    #17 0x5577b236a639 in RUN_ALL_TESTS() rapidjson/thirdparty/gtest/googletest/include/gtest/gtest.h:2329
    #18 0x5577b236a579 in main rapidjson/test/unittest/unittest.cpp:44
    #19 0x7f09a299dd8f in __libc_start_call_main ../sysdeps/nptl/libc_start_call_main.h:58
    #20 0x7f09a299de3f in __libc_start_main_impl ../csu/libc-start.c:392
    #21 0x5577b18a6754 in _start (rapidjson/build/Bullettech/Debug/bin/unittest+0xc1754) (BuildId: eea20f0c45e248ded253202f86e529ebdb50cb0e)

Address 0x7f09a11d3af4 is located in stack of thread T0 at offset 15092 in frame
    #0 0x5577b1b8ba63 in Reader_ParseString_Error_Test::TestBody() rapidjson/test/unittest/readertest.cpp:908

  This frame has 474 object(s):
    [48, 49) 'h' (line 935)
    ...
    [14976, 15048) 'reader' (line 1046)
    [15088, 15092) 'e' (line 992) <== Memory access at offset 15092 overflows this variable
    [15104, 15110) 'e' (line 960)
    [15136, 15143) 'e' (line 972)
HINT: this may be a false positive if your program uses some custom stack unwind mechanism, swapcontext or vfork
      (longjmp and C++ exceptions *are* supported)
SUMMARY: AddressSanitizer: stack-buffer-overflow rapidjson/include/rapidjson/stream.h:160 in rapidjson::GenericStringStream<rapidjson::UTF8<char> >::Take()
Shadow bytes around the buggy address:
  0x7f09a11d3800: 00 00 00 00 00 f2 f2 f2 f2 f2 00 00 00 00 00 00
  0x7f09a11d3880: 00 00 00 f2 f2 f2 f2 f2 00 00 00 00 00 00 00 00
  0x7f09a11d3900: 00 f2 f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 f2
  0x7f09a11d3980: f2 f2 f2 f2 00 00 00 00 00 00 00 00 00 f2 f2 f2
  0x7f09a11d3a00: f2 f2 00 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2
=>0x7f09a11d3a80: 00 00 00 00 00 00 00 00 00 f2 f2 f2 f2 f2[04]f2
  0x7f09a11d3b00: f8 f2 f2 f2 f8 f3 f3 f3 00 00 00 00 00 00 00 00
  0x7f09a11d3b80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f09a11d3c00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f09a11d3c80: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7f09a11d3d00: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==82872==ABORTING
```

without ASAN:

```
[ RUN      ] Reader.ParseString_Error
rapidjson/test/unittest/readertest.cpp:1004: Failure
Expected equality of these values:
  streamPos
    Which is: 4
  s.Tell()
    Which is: 5
rapidjson/test/unittest/readertest.cpp:1004: Failure
Expected equality of these values:
  streamPos
    Which is: 4
  s.Tell()
    Which is: 5
rapidjson/test/unittest/readertest.cpp:1004: Failure
Expected equality of these values:
  streamPos
    Which is: 4
  s.Tell()
    Which is: 5
rapidjson/test/unittest/readertest.cpp:1004: Failure
Expected equality of these values:
  streamPos
    Which is: 4
  s.Tell()
    Which is: 5
rapidjson/test/unittest/readertest.cpp:1004: Failure
Expected equality of these values:
  streamPos
    Which is: 4
  s.Tell()
    Which is: 5
[  FAILED  ] Reader.ParseString_Error (0 ms)
```