### PR TITLE
fix: UB in `SchemaValidator::Double` when casting out-of-range doubles

### DIFF
--- a/include/rapidjson/schema.h
+++ b/include/rapidjson/schema.h
@@ -341,8 +341,14 @@ public:
     bool Uint64(uint64_t u) { Number n; n.u.u = u; n.d = static_cast<double>(u); return WriteNumber(n); }
     bool Double(double d) {
         Number n;
-        if (d < 0) n.u.i = static_cast<int64_t>(d);
-        else       n.u.u = static_cast<uint64_t>(d);
+        if (d < 0)
+            // INT64_MIN (-2^63) is exactly representable as double; cast is UB outside that range
+            n.u.i = d >= static_cast<double>((std::numeric_limits<int64_t>::min)())
+                    ? static_cast<int64_t>(d) : 0;
+        else
+            // 2^64 is exactly representable as double; any d in [0, 2^64) fits in uint64_t
+            n.u.u = d < 18446744073709551616.0
+                    ? static_cast<uint64_t>(d) : 0;
         n.d = d;
         return WriteNumber(n);
     }

--- a/test/unittest/schematest.cpp
+++ b/test/unittest/schematest.cpp
@@ -3573,6 +3573,38 @@ TEST(SchemaValidator, NullableFalse) {
         "}}");
 }
 
+TEST(SchemaValidator, UniqueItemsDoubleOutOfIntRangeUB) {
+    Document sd;
+    sd.Parse("{\"type\":\"array\",\"uniqueItems\":true}");
+    ASSERT_FALSE(sd.HasParseError());
+    SchemaDocument schema(sd);
+
+    // Large positive doubles well outside uint64_t range (~1.8e19 max)
+    {
+        SchemaValidator v(schema);
+        Document doc;
+        doc.Parse("[1e33, 2e33]");
+        ASSERT_FALSE(doc.HasParseError());
+        EXPECT_TRUE(doc.Accept(v));  // unique — must not crash or misidentify
+    }
+    {
+        SchemaValidator v(schema);
+        Document doc;
+        doc.Parse("[1e33, 1e33]");
+        ASSERT_FALSE(doc.HasParseError());
+        EXPECT_FALSE(doc.Accept(v));  // duplicates
+    }
+
+    // Large negative doubles outside int64_t range (~-9.2e18 min)
+    {
+        SchemaValidator v(schema);
+        Document doc;
+        doc.Parse("[-1e33, -2e33]");
+        ASSERT_FALSE(doc.HasParseError());
+        EXPECT_TRUE(doc.Accept(v));  // unique
+    }
+}
+
 #if defined(_MSC_VER) || defined(__clang__)
 RAPIDJSON_DIAG_POP
 #endif


### PR DESCRIPTION
## What is this PR?

This PR fixes an undefined behaviour happening when trying to cast a `double` to an integer (`int64_t` or `uint64_t`) outside its valid range. 

```
/home/user/rapidjson/include/rapidjson/schema.h:345:50: runtime error: 1e+33 is outside the range of representable values of type 'unsigned long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/user/rapidjson/include/rapidjson/schema.h:345:50 in
MS: 4 ChangeByte-ChangeByte-InsertRepeatedBytes-CrossOver-; base unit: d06ccadf2965827126a941a193346fc522f20a85
```

The proposed fix is to set the integer representation to 0 if it's outside the valid value range. 

The PR also adds a test validating the new behaviour.